### PR TITLE
Fixed issues with sticky nav and mobile version

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -72,12 +72,11 @@
         <li><a class='twitter' href="https://twitter.com/learnosm">@learnOSM</a></li>
         <li><a class='github' href='http://github.com/hotosm/learnosm'> Hosted on Github</a></li>
       </ul>
+      <a rel="license" class="license" href="http://creativecommons.org/publicdomain/zero/1.0/">
+      	<img src="http://i.creativecommons.org/p/zero/1.0/80x15.png" alt="CC0" />
+      </a>
       <div class='sponsors cell3 padAll'>
         <span>Official <a href='http://hot.openstreetmap.org/' target='_blank'>HOT OSM</a> learning materials</span>
-        <a rel="license" class="license"
-           href="http://creativecommons.org/publicdomain/zero/1.0/">
-          <img src="http://i.creativecommons.org/p/zero/1.0/80x15.png" alt="CC0" />
-        </a>
         <a class='logo logo-hot left' href='http://hot.openstreetmap.org/' target='_blank'></a>
         <a class='logo logo-ausaid left' href='http://www.ausaid.gov.au/' target='_blank'></a>
         <a class='logo logo-bnpb left' href='http://www.bnpb.go.id/' target='_blank'></a>

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -53,19 +53,36 @@ layout: default
 
   //select the image containers so the images can be centered, styles in css
   $('img').parent().addClass('has-image');
-
+  
   // make title nav sticky
   {% unless {{page.cover}} %} // excluding cover pages
-  var nav = $('.doc-nav'),
-      navTop = nav.offset().top;
+  $(document).ready(function(){
+  	var nav = $('.doc-nav'),
+      	navTop = nav.offset().top,
+      	navHeight = nav.outerHeight(true),
+      	footerHeight = $('#footer').outerHeight(true);
 
-  $(window).scroll(function(e){
-    var windowTop = $(this).scrollTop();
-    if (windowTop >= navTop) {
-      nav.addClass('fixed');
-    } else {
-      nav.removeClass('fixed');
-    }
+  	$(window).scroll(function(e){
+    	var scrolled = $(this).scrollTop();
+    	var leftToScroll = $(document).height() - scrolled;
+    	
+    	if (scrolled >= navTop && leftToScroll > (footerHeight + navHeight + 20)) {
+    	// if in the middle - nav box is positioned fixed
+      		nav.addClass('fixed');
+      		nav.removeClass('bottom');
+    	} else if (scrolled < navTop) {
+    	// if at the beginning - nav box is positioned at top
+      		nav.removeClass('fixed');
+      		nav.removeClass('bottom');
+    	} else if (leftToScroll <= (footerHeight + navHeight + 20)) {
+    	// if at the end - nav box is positioned at bottom
+    	// only if height of viewport is not sufficient to have nav box and footer in it
+    		if ((footerHeight + navHeight + 20) > $(window).height()) {
+	      		nav.removeClass('fixed');
+    	  		nav.addClass('bottom');
+    	  	}
+    	}
+  	});
   });
   {% endunless %}
 

--- a/style.css
+++ b/style.css
@@ -375,9 +375,9 @@ body {
     .github:hover:before {background-position:-80px -178px;}
 .sponsors span {display:block;}
   .sponsors span a {color:#fc3f51;}
-.sponsors a.license {
+a.license {
   position:absolute;
-  margin:-37px 0 0 190px;
+  left:360px;
   }
 .sponsors a.logo {margin-top:30px;}
   .sponsors a.logo-hot {background-position:0 0;}
@@ -463,10 +463,15 @@ body {
 /* doc nav */
 .doc-nav {
   position:absolute;
+  padding-top: 30px;
 }
 .doc-nav.fixed {
   position:fixed;
-  top:10px;
+  top: 0;
+}
+.doc-nav.bottom {
+  positon:absolute;
+  bottom: 200px;
 }
 .doc-nav ul li a {
   white-space: nowrap;
@@ -667,14 +672,19 @@ body {
   #ads a {border-radius:0;}
   #ads .ad1, #ads .ad2, #ads .ad3 {height:auto;}
   #ads .ad1 a, #ads .ad2 a, #ads .ad3 a {margin:0;}
-  #ads .ad1 span.door {margin-top:-60px;}
+  /*#ads .ad1 span.door {margin-top:-60px;}*/
   #footer {position:relative;}
   .searchbox-default {padding-left:10px;float:left;}
   .searchbox {border-radius:0px; border:8px solid #f0f0f0;}
   .searchbox input {width:200px;}
   .doc-nav,.doc-nav.fixed {position:relative;margin-bottom:20px;}
-  .doc-main {margin-left:0%;}
-  .feedback {padding-top:20px;}
+  .doc-main {margin-left:0%}
+  .feedback {padding-top:20px;padding-left:15px;}
   .notfound {width:300px;}
   img {max-width:300px;}
+  .doc h1, .doc p, .doc ul, .doc ol {margin-left:15px;width:95%;}
+  .doc h2, .doc h3 {margin-left:30px;width:95%;}
+  #content {padding-bottom:50px;}
+  #footer {padding-left:15px;}
+  a.license {left:250px;top:10px;}
   }


### PR DESCRIPTION
Description of changes:
#### Footer
- For smaller viewports the license tag may be cut off at the right, no content should go
  beyond the right end of the document text. I have moved the license tag elsewhere.
#### Sticky Nav
- When the nav becomes sticky it jumps a little bit. This is caused by the `top: 10px` in
  `.doc-nav.fixed`. To solve this issue and to keep the larger top padding for the nav box
  a `padding-top: 30px` at `.doc-nav` should be placed.
- For smaller viewports the nav box may be partially obscured by the footer when scrolling
  towards the end. Here the nav box needs an additional 3rd state, the states are then:
  normal (top), fixed, normal (bottom). However, for larger viewports there should be no 3rd state because
  the nav box may then jump towards the bottom of the site when scrolling down.
#### Mobile Version
- added padding to the text of the guides. (This was not possible for the other pages.)
- reduced the space above the footer
- added left padding to footer
- removed negative margin for "door"
