### PR TITLE
small error

### DIFF
--- a/_posts/en/beginner/0200-12-28-start-josm.md
+++ b/_posts/en/beginner/0200-12-28-start-josm.md
@@ -34,8 +34,7 @@ Download JOSM
 
   ![JOSM website][]
 
-- If you have Windows installed on your computer, click “Windows JOSM
-  Installer” to download JOSM.
+- If you have Windows installed on your computer, click “Windows Installer” to download JOSM.
 
   ![Windows installer][]
 


### PR DESCRIPTION
When you want to download the JOSM Windows installer from the JOSM website, the link says "Windows installer", not "Windows JOSM installer"
