### PR TITLE
fixing italian duplications

### DIFF
--- a/_posts/it/editing/0300-10-31-id-editor.md
+++ b/_posts/it/editing/0300-10-31-id-editor.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: iD Editor
-permalink: /en/editing/id-editor/
-lang: en
+permalink: /it/editing/id-editor/
+lang: it
 category: editing
 ---
 

--- a/_posts/it/editing/0300-11-12-josm-conflict-resolution.md
+++ b/_posts/it/editing/0300-11-12-josm-conflict-resolution.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: Conflict Resolution
-permalink: /en/editing/conflict-resolution/
-lang: en
+permalink: /it/editing/conflict-resolution/
+lang: it
 category: editing
 ---
 

--- a/_posts/it/editing/0300-11-15-correcting-imagery-offset.md
+++ b/_posts/it/editing/0300-11-15-correcting-imagery-offset.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: Correcting Imagery Offset
-permalink: /en/editing/correcting-imagery-offset/
-lang: en
+permalink: /it/editing/correcting-imagery-offset/
+lang: it
 category: editing
 ---
 

--- a/_posts/it/editing/0300-11-16-aerial-imagery.md
+++ b/_posts/it/editing/0300-11-16-aerial-imagery.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: Aerial Imagery
-permalink: /en/editing/aerial-imagery/
-lang: en
+permalink: /it/editing/aerial-imagery/
+lang: it
 category: editing
 ---
 

--- a/_posts/it/editing/0300-11-18-editing-techniques.md
+++ b/_posts/it/editing/0300-11-18-editing-techniques.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: Editing Techniques
-permalink: /en/editing/josm-editing-techniques/
-lang: en
+permalink: /it/editing/josm-editing-techniques/
+lang: it
 category: editing
 ---
 

--- a/_posts/it/editing/0300-11-20-josm-relations.md
+++ b/_posts/it/editing/0300-11-20-josm-relations.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: JOSM Relations
-permalink: /en/editing/josm-relations/
-lang: en
+permalink: /it/editing/josm-relations/
+lang: it
 category: editing
 ---
 

--- a/_posts/it/editing/0300-11-26-creating-custom-presets.md
+++ b/_posts/it/editing/0300-11-26-creating-custom-presets.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: Creating Custom Presets
-permalink: /en/editing/creating-presets/
-lang: en
+permalink: /it/editing/creating-presets/
+lang: it
 category: editing
 ---
 

--- a/_posts/it/editing/0300-11-27-josm-presets.md
+++ b/_posts/it/editing/0300-11-27-josm-presets.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: JOSM Presets
-permalink: /en/editing/josm-presets/
-lang: en
+permalink: /it/editing/josm-presets/
+lang: it
 category: editing
 ---
 

--- a/_posts/it/editing/0300-11-28-josm-more-tools.md
+++ b/_posts/it/editing/0300-11-28-josm-more-tools.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: More Tools
-permalink: /en/editing/more-tools/
-lang: en
+permalink: /it/editing/more-tools/
+lang: it
 category: editing
 ---
 

--- a/_posts/it/editing/0300-11-29-josm-plugins.md
+++ b/_posts/it/editing/0300-11-29-josm-plugins.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: JOSM Plugins
-permalink: /en/editing/josm-plugins/
-lang: en
+permalink: /it/editing/josm-plugins/
+lang: it
 category: editing
 ---
 

--- a/_posts/it/editing/0300-11-30-josm-tools.md
+++ b/_posts/it/editing/0300-11-30-josm-tools.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: JOSM Tools
-permalink: /en/editing/josm-tools/
-lang: en
+permalink: /it/editing/josm-tools/
+lang: it
 category: editing
 ---
 

--- a/_posts/it/editing/0300-12-31-editing.md
+++ b/_posts/it/editing/0300-12-31-editing.md
@@ -1,7 +1,7 @@
 ---
 layout: doc
-permalink: /en/editing/
-lang: en
+permalink: /it/editing/
+lang: it
 title: Detailed Editing
 category: editing
 cover: yes

--- a/_posts/it/map-design/0700-11-29-tilemill.md
+++ b/_posts/it/map-design/0700-11-29-tilemill.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: Cartography With TileMill
-permalink: /en/map-design/tilemill/
-lang: en
+permalink: /it/map-design/tilemill/
+lang: it
 category: map-design
 ---
 

--- a/_posts/it/map-design/0700-11-30-mapbox.md
+++ b/_posts/it/map-design/0700-11-30-mapbox.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: Putting Maps on a Website with MapBox
-permalink: /en/map-design/mapbox/
-lang: en
+permalink: /it/map-design/mapbox/
+lang: it
 category: map-design
 ---
 

--- a/_posts/it/map-design/0700-12-31-map-design.md
+++ b/_posts/it/map-design/0700-12-31-map-design.md
@@ -1,7 +1,7 @@
 ---
 layout: doc
-permalink: /en/map-design/
-lang: en
+permalink: /it/map-design/
+lang: it
 title: Map Design
 category: map-design
 cover: yes

--- a/_posts/it/osm-data/0600-12-08-osmosis.md
+++ b/_posts/it/osm-data/0600-12-08-osmosis.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: Manipulating Data with Osmosis
-permalink: /en/osm-data/osmosis/
-lang: en
+permalink: /it/osm-data/osmosis/
+lang: it
 category: osm-data
 ---
 

--- a/_posts/it/osm-data/0600-12-09-osm2pgsql.md
+++ b/_posts/it/osm-data/0600-12-09-osm2pgsql.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: osm2pgsql
-permalink: /en/osm-data/osm2pgsql/
-lang: en
+permalink: /it/osm-data/osm2pgsql/
+lang: it
 category: osm-data
 ---
 

--- a/_posts/it/osm-data/0600-12-10-setting-up-postgresql.md
+++ b/_posts/it/osm-data/0600-12-10-setting-up-postgresql.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: Setting up PostgreSQL
-permalink: /en/osm-data/setting-up-postgresql/
-lang: en
+permalink: /it/osm-data/setting-up-postgresql/
+lang: it
 category: osm-data
 ---
 

--- a/_posts/it/osm-data/0600-12-13-osm-in-qgis.md
+++ b/_posts/it/osm-data/0600-12-13-osm-in-qgis.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: OSM Data in QGIS
-permalink: /en/osm-data/osm-in-qgis/
-lang: en
+permalink: /it/osm-data/osm-in-qgis/
+lang: it
 category: osm-data
 ---
 

--- a/_posts/it/osm-data/0600-12-15-getting-data.md
+++ b/_posts/it/osm-data/0600-12-15-getting-data.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: Getting OSM Data
-permalink: /en/osm-data/getting-data/
-lang: en
+permalink: /it/osm-data/getting-data/
+lang: it
 category: osm-data
 ---
 

--- a/_posts/it/osm-data/0600-12-20-file-formats.md
+++ b/_posts/it/osm-data/0600-12-20-file-formats.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: File Formats
-permalink: /en/osm-data/file-formats/
-lang: en
+permalink: /it/osm-data/file-formats/
+lang: it
 category: osm-data
 ---
 

--- a/_posts/it/osm-data/0600-12-30-data-overview.md
+++ b/_posts/it/osm-data/0600-12-30-data-overview.md
@@ -1,8 +1,8 @@
 ---
 layout: doc
 title: OSM Data Overview
-permalink: /en/osm-data/data-overview/
-lang: en
+permalink: /it/osm-data/data-overview/
+lang: it
 category: osm-data
 ---
 

--- a/_posts/it/osm-data/0600-12-31-osm-data.md
+++ b/_posts/it/osm-data/0600-12-31-osm-data.md
@@ -1,7 +1,7 @@
 ---
 layout: doc
-permalink: /en/osm-data/
-lang: en
+permalink: /it/osm-data/
+lang: it
 title: OSM Data
 category: osm-data
 cover: yes


### PR DESCRIPTION
Slight problem with new Italian translation causes some hiccups in the English.  Replacing en/ with it/ in the headers to fix.
