### PR TITLE
added permalinks to bottom pages of beginner guide for "next sections"

### DIFF
--- a/_posts/en/beginner/0200-12-23-editing-with-josm.md
+++ b/_posts/en/beginner/0200-12-23-editing-with-josm.md
@@ -188,6 +188,12 @@ In the final section of this guide we will look at other resources you can learn
 as you move forward. As you practice what you've learned here and explore further,
 you will get better and better at making maps with OSM.
 
+Moving Forward
+--------------
+
+Click on the link for further reading on:  
+
+*  [Learning Beyond the Beginner Guide](/en/beginner/moving-forward/)
 
 [Layers panel]: /images/en/beginner/07_editing-with-josm/en_beg_07_editing-with-josm_image00_layers-panel.png
 [Layers up down]: /images/en/beginner/07_editing-with-josm/en_beg_07_editing-with-josm_image01_layers-panel-up-down.png

--- a/_posts/en/beginner/0200-12-24-papers.md
+++ b/_posts/en/beginner/0200-12-24-papers.md
@@ -284,6 +284,14 @@ Congratulations! In this chapter you learned the process of using
 Field Papers and how they work. You learned how to print, map, and
 scan a Field Paper, and how you can use them to improve OpenStreetMap.
 
+Moving Forward
+--------------
+
+Click on the link for further reading on:  
+
+*  [Surveying with GPS](/en/beginner/using-gps/)  
+*  [Editing Field Data](/en/beginner/editing-with-josm/) 
+
 [FieldPapers homepage]: /images/en/beginner/06_field-papers/en_beg_06_field-papers_image00_homepage.png
 [Example fieldpaper print]: /images/en/beginner/06_field-papers/en_beg_06_field-papers_image01_fieldp.png
 [Fieldpaper scan as a JOSM background]: /images/en/beginner/06_field-papers/en_beg_06_field-papers_image02_fieldpaperjosm.png

--- a/_posts/en/beginner/0200-12-26-gps.md
+++ b/_posts/en/beginner/0200-12-26-gps.md
@@ -290,6 +290,13 @@ places to OpenStreetMap.
 The next chapter is about a different survey method, known as Field Papers.
 These allow you to make maps without the need for a GPS!
 
+Moving Forward
+--------------
+
+Click on the link for further reading on:  
+
+*  [Field Papers](/en/beginner/field-papers/)  
+*  [Editing Field Data](/en/beginner/editing-with-josm/)  
 
 [Google Earth software, showing coordinates of Lombok, Indonesia]: /images/en/beginner/05_gps/en_beg_05_gps_image00_google-earth-lombok.png
 [Garmin eTrex Vista HCx]: /images/en/beginner/05_gps/en_beg_05_gps_image01_garmin-etrex.png

--- a/_posts/en/beginner/0200-12-27-more-about-josm.md
+++ b/_posts/en/beginner/0200-12-27-more-about-josm.md
@@ -205,6 +205,16 @@ In the next sections we will learn about two methods - GPS and Field Papers,
 which are used to collect geographic data. The information from both of these
 can then be imported into JOSM, and used to edit the map.
 
+Moving Forward
+--------------
+
+Click on the link for further reading on:  
+ 
+*  [Surveying with GPS](/en/beginner/using-gps/)  
+*  [Field Papers](/en/beginner/field-papers/)
+*  [Editing Field Data](/en/beginner/editing-with-josm/) 
+
+
 [JOSM Download Button]: /images/en/beginner/04_more-about-josm/eng_beg_04_more-about-josm_image00_download-button.png
 [JOSM Download Dialog]: /images/en/beginner/04_more-about-josm/eng_beg_04_more-about-josm_image01_download-dialog.png
 [JOSM Preferences up down]: /images/en/beginner/04_more-about-josm/eng_beg_04_more-about-josm_image02_preferences-up-down.png

--- a/_posts/en/beginner/0200-12-29-start-osm.md
+++ b/_posts/en/beginner/0200-12-29-start-osm.md
@@ -188,8 +188,8 @@ Moving Forward
 
 Click on the link for further reading on:  
 
-*  [To continue with this beginner series & to learn about JOSM](/en/beginner/start-josm/)  
-*  [LearnOSM section on iD editor](/en/editing/id-editor/)  
+*  [Getting started with the iD editor](/en/editing/id-editor/)   
+*  [Getting started with the JOSM editor](/en/beginner/start-josm/) 
 *  [To continue with the Remote, Armchair or Mapathon section of LearnOSM](/en/coordination/remote/)  
 
 

--- a/_posts/en/beginner/0200-12-30-introduction.md
+++ b/_posts/en/beginner/0200-12-30-introduction.md
@@ -70,6 +70,15 @@ We hope that you will find OpenStreetMap useful and interesting in your
 work. By following this guide, you should be able to quickly start
 making digital maps with OpenStreetMap.
 
+Moving Forward
+--------------
+
+Click on the link for further reading on:  
+
+*  [Getting started on OpenStreetMap.org](/en/beginner/start-osm/) 
+*  [Getting started with the iD editor](/en/editing/id-editor/)   
+*  [Getting started with the JOSM editor](/en/beginner/start-josm/)  
+
 
 [A village in Indonesia]: /images/en/beginner/01_introduction/en_beg_01_introduction_image00_village-in-indonesia.png
 [Example of a hand-drawn map]: /images/en/beginner/01_introduction/en_beg_01_introduction_image01_hand-drawn-map.png


### PR DESCRIPTION
 Followed Nick-Tallguy's suggestion of adding manual permalinks to the next sections under the heading "Moving Forward." Open to renaming or reorganizing the links and other semantic changes as others see fit. 