### PR TITLE
fixed a type and small rewording of the intro small page

### DIFF
--- a/_posts/es/coordination/0500-12-31-coordination.md
+++ b/_posts/es/coordination/0500-12-31-coordination.md
@@ -12,6 +12,6 @@ nosearch: true
 Coordinación
 ============
 
-Como OpenStretMap involucra a mucha gente al mismo tiempo, es útil saber cómo los contribuidores coordinan esta actividad.
+Como OpenStreetMap involucra a mucha gente al mismo tiempo, es útil saber cómo se coordinan los contribuidores a esta actividad.
 
-Esta sección de LearnOSM proporciona información sobre varias herramientas utilizadas para coordinar a las comunidades de edición cartográfica, medios de comunicación y sistemas de gestión de la calidad de los datos.
+Esta sección de LearnOSM proporciona información sobre varias herramientas utilizadas para coordinar a las comunidades de edición cartográfica, qué medios de comunicación utilizan y diversos sistemas de gestión de la calidad de los datos.


### PR DESCRIPTION
I found small typo on the front page on the coordination guide. I also reworded a little bit the text.