### PR TITLE
Update app download link in play store

### DIFF
--- a/_posts/en/0900-12-05-osmtracker.md
+++ b/_posts/en/0900-12-05-osmtracker.md
@@ -31,7 +31,7 @@ Quick Start
 Install OSMTracker
 -------------------------
 
-Install OSMTracker from the [Google play Store](https://play.google.com/store/apps/details?id=me.guillaumin.android.osmtracker).  
+Install OSMTracker from the [Google play Store](https://play.google.com/store/apps/details?id=net.osmtracker).  
 ![OSMTracker Logo][]  
 The [most recent application package](https://drive.google.com/folderview?id=0BxxhTXmYjyeSSjg1MFhJWnJLams#list) can be downloaded outside of Google play Store if need be.  
 


### PR DESCRIPTION
The package name of OSMTracker was changed when the app was transferred by the former developer. (more info: https://github.com/labexp/osmtracker-android/issues/137#issuecomment-396437696)