### PR TITLE
Various responsive CSS fixes

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -147,7 +147,7 @@
           </a>
       </li>
       </ul>
-      <div class='sponsors cell3 padAll'>
+      <div class='sponsors cell6 padAll'>
         <span>Official <a href='https://hot.openstreetmap.org/' target='_blank'>HOT OSM</a> learning materials</span>
         <a class='logo logo-hot left' href='https://hot.openstreetmap.org/' target='_blank'></a>
         <a class='logo logo-ausaid left' href='https://en.wikipedia.org/wiki/Australian_Aid' target='_blank'></a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,7 +26,7 @@
   </head>
   <body>
    <div id='wrapper'>
-    <div class="fillG cell11" id="banner-top">
+    <div class="fillG cell12" id="banner-top">
       <div class="dropdown language-switcher marginL"> <span> {{site.translations[page.lang].language}} ... </span>
         <div class='language-switcher dropdown-content'>
           {% assign start_page = "/" | append: page.lang | append: "/" | strip %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -136,22 +136,24 @@
     <div id='content' class='cf'>
         {{ content }}
     </div>
-    <small id='footer' class='fillG cell12'>
+    <footer id='footer' class='fillG cell12'>
       <ul class='contact marginL marginR cell3 padAll'>
         <li><a class='email' href="mailto:learnosm@hotosm.org">learnosm@hotosm.org</a></li>
         <li><a class='twitter' href="https://twitter.com/learnosm">@learnOSM</a></li>
         <li><a class='github' href='https://github.com/hotosm/learnosm'> Hosted on Github</a></li>
+        <li>
+          <a rel="license" class="license" href="https://creativecommons.org/publicdomain/zero/1.0/">
+            <img src="https://i.creativecommons.org/p/zero/1.0/80x15.png" alt="CC0" />
+          </a>
+      </li>
       </ul>
-      <a rel="license" class="license" href="https://creativecommons.org/publicdomain/zero/1.0/">
-      	<img src="https://i.creativecommons.org/p/zero/1.0/80x15.png" alt="CC0" />
-      </a>
       <div class='sponsors cell3 padAll'>
         <span>Official <a href='https://hot.openstreetmap.org/' target='_blank'>HOT OSM</a> learning materials</span>
         <a class='logo logo-hot left' href='https://hot.openstreetmap.org/' target='_blank'></a>
         <a class='logo logo-ausaid left' href='https://en.wikipedia.org/wiki/Australian_Aid' target='_blank'></a>
         <a class='logo logo-bnpb left' href='https://www.bnpb.go.id/' target='_blank'></a>
       </div>
-    </small>
+    </footer>
   </div>
   <div id="optout-form"></div>
   </body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,7 +27,7 @@
   <body>
    <div id='wrapper'>
     <div class="fillG cell12" id="banner-top">
-      <div class="dropdown language-switcher marginL"> <span> {{site.translations[page.lang].language}} ... </span>
+      <div class="dropdown language-switcher"> <span> {{site.translations[page.lang].language}} ... </span>
         <div class='language-switcher dropdown-content'>
           {% assign start_page = "/" | append: page.lang | append: "/" | strip %}
           {% assign contribute_page = "/" | append: page.lang | append: "/contribute/" | strip %}

--- a/_layouts/doc-rtl.html
+++ b/_layouts/doc-rtl.html
@@ -6,7 +6,7 @@ layout: default
 <!-- First the navigation bar on the right side -->
 
 <div class='doc-nav marginR cell3 padAll cf' id='doc-nav-left'>
-  <ul style="margin-top:40px;">
+  <ul>
       <li class='doc rounded'>
         <a class='title cover'>
           {% if page.otherguides %}

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -5,7 +5,7 @@ layout: default
 <!-- First the navigation bar on the left side -->
 
 <div class='doc-nav marginL cell3 padAll cf' id='doc-nav-left'>
-  <ul style="margin-top:40px;">
+  <ul>
       <li class='doc rounded'>
         <a class='title cover'>
           {% if page.otherguides %}

--- a/_layouts/front-rtl.html
+++ b/_layouts/front-rtl.html
@@ -25,7 +25,7 @@ layout: default
 </div>
 <div class='marginL cell9 padAll'>
   <form class='searchbox rounded'>
-    <span class='logo logo-search'></span>
+    <span class='logo logo-search' style='margin-top: 0px;'></span>
     <input id='search-field' type='text' name='search' class='default-value cell10'></input>
   </form>
 </div>

--- a/_layouts/front.html
+++ b/_layouts/front.html
@@ -24,7 +24,7 @@ layout: default
 </div>
 <div class='marginL cell9 padAll'>
   <form class='searchbox rounded'>
-    <span class='logo logo-search'></span>
+    <span class='logo logo-search' style='margin-top: 0px;'></span>
     <input id='search-field' type='text' name='search' class='default-value cell10'></input>
   </form>
 </div>

--- a/_layouts/front.html
+++ b/_layouts/front.html
@@ -1,74 +1,251 @@
----
-layout: default
----
-<div id='ads' class='marginL cell9 padAll'>
-  <div class='ad1 cell8 {% case page.lang %}{% when 'hr' %}no-capitalize{% else %}{% endcase %}'>
-    <a href='{{site.baseurl}}/{{page.lang}}/beginner'>
-      <span class='ad-title'>{{ page.begspan }}</span>
-      <span class='ad-txt'>{{ page.beg }}</span>
-      <span class='door'></span>
-    </a>
-  </div>
-  <div class='ad2 cell4 {% case page.lang %}{% when 'hr' %}no-capitalize{% else %}{% endcase %}'>
-    <a href='{{page.interspanlink}}'>
-      <span class='ad-title'>{{page.interspan}}</span>
-      <span class='ad-txt'>{{ page.inter }}</span>
-    </a>
-  </div>
-  <div class='ad3 cell4 {% case page.lang %}{% when 'hr' %}no-capitalize{% else %}{% endcase %}'>
-    <a href='{{page.advspanlink}}'>
-      <span class='ad-title'>{{page.advspan}}</span>
-      <span class='ad-txt'>{{page.adv}}</span>
-    </a>
-  </div>
-</div>
-<div class='marginL cell9 padAll'>
-  <form class='searchbox rounded'>
-    <span class='logo logo-search' style='margin-top: 0px;'></span>
-    <input id='search-field' type='text' name='search' class='default-value cell10'></input>
-  </form>
-</div>
-<div id='front' class='marginL cell9 padAll'>
-  <div class='front-text cell7 marginR'>
-    <h4 class='tagtitle'>{{ page.fronttitle }}</h4>
-    <p class='tagwords'>{{ page.frontintro }}</p>
-  </div>
-  <div class='faqbox cell4'>
-    <h4>{{page.faq}}</h4>
-    <ul class='faq'>
-      <li><a href='{{site.baseurl}}/{{page.lang}}/beginner/introduction/'>{{page.faqA}}</a></li>
-      <li><a href='{{site.baseurl}}/{{page.lang}}/beginner/start-osm/#beginning-osm-create-an-openstreetmap-account'>{{page.faqC}}</a></li>
-      <li><a href='{{site.baseurl}}/{{page.lang}}/beginner/moving-forward/'>{{page.faqD}}</a></li>
-      <li><a href='{{site.baseurl}}/{{page.lang}}/contribute/'>{{page.faqB}}</a></li>
-  </div>
-</div>
-<script>
-// detect if ad is overflowing
-var spanTitle = $('span.ad-title','#ads');
-  $.each(spanTitle, function(i,el){
-  var titleParent = el.parentElement,
-      titleSister = el.nextElementSibling;
-  var titleHeight = el.offsetHeight,
-      txtHeight = titleSister.offsetHeight,
-      adHeight = titleParent.offsetHeight;
-  if (titleHeight + txtHeight > adHeight) {
-    titleSister.style.display = 'none'
-  } 
-});
-// format the search bar on the front
-var input = $(".searchbox input[type=text]"),
-  inputTitle = "{{page.searchtext}}"; //needs tranlation
-  input.val(inputTitle);
+<!DOCTYPE html>
+<html lang="{{page.lang}}">
+  <head>
+    <meta charset="UTF-8">
+    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no'>
+    <title>LearnOSM</title>
+    <link href="{{ site.baseurl }}/reset.css" rel="stylesheet" type="text/css">
+    <link href="{{ site.baseurl }}/style.css" rel="stylesheet" type="text/css">
+    <link href="{{ site.baseurl }}/print.css" rel="stylesheet" type="text/css" media="print">
+    <link rel='shortcut icon' href='{{site.baseurl}}/img/favicon.ico' type='image/x-icon' />
+    <link href="https://code.jquery.com/ui/1.9.2/themes/base/jquery-ui.css" rel="stylesheet" >
+    <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,400italic|Quattrocento+Sans:400,700&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+    <script src="{{ site.baseurl }}/vendor/jquery-1.8.2.min.js"></script>
+    <script src="{{ site.baseurl }}/vendor/jquery-ui-1.9.2.custom.js"></script>
+    <script>
+      window.app = window.app || {};
+      window.app.permalink = '{{page.permalink}}';
+      window.app.baseurl = '{{site.baseurl}}';
+      window.app.lang = '{{page.lang}}';
+    </script>
+    <script src="{{ site.baseurl }}/site.js"></script>
+    <!-- Matomo -->
+    <script type="application/javascript">var site_id="3";</script>
+    <script type="application/javascript" src="https://cdn.hotosm.org/tracking-v1.js"></script>
+    <!-- End Matomo -->
+  </head>
+  <body>
+   <div id='wrapper'>
+    <div class="fillG cell12" id="banner-top">
+      <div class="dropdown language-switcher marginL"> <span> {{site.translations[page.lang].language}} ... </span>
+        <div class='language-switcher dropdown-content'>
+          {% assign start_page = "/" | append: page.lang | append: "/" | strip %}
+          {% assign contribute_page = "/" | append: page.lang | append: "/contribute/" | strip %}
+          {% assign this_page = page.permalink | strip %}
 
-input.blur(function() {
-if (input.val() === "") {
-    input.val(inputTitle); // restore default text
-    input.addClass("default-value");
-}
-}).focus(function() {
-  if (input.val() === inputTitle) {
-      input.val("");
-      input.removeClass("default-value");
-  }
-});
-</script>
+          {% if this_page == start_page %} <!-- always show title page -->
+            {% for lingua in site.translations %}
+              <a lang='{{lingua[0]}}'>{{lingua[1].language}}</a><br>
+            {% endfor %}
+
+          {% elsif this_page == contribute_page %} <!-- always show contribute page -->
+            {% for lingua in site.translations %}
+              <a lang='{{lingua[0]}}'>{{lingua[1].language}}</a><br>
+            {% endfor %}
+
+          {% else %}
+            {% assign supported = "" %}
+            {% assign remover = "/" | append: page.lang | append: "/" | append: page.category %}
+            {% assign page_name = page.permalink | remove: remover %}
+
+            <!-- find out which pages with the same name exist in which languages -->
+            {% for post in site.categories[page.category] %}
+              {% assign remover = "/" | append: post.lang | append: "/" | append: post.category %}
+              {% assign testee = post.permalink | remove: remover %}
+              {% if page_name == testee %}
+                {% assign supported = supported | append: post.lang | append: ' ' %}
+              {% endif %}
+            {% endfor %}
+
+            <!-- make a link for those languages where the page exists, plain text otherwise -->
+            {% for lingua in site.translations %}
+              {% if supported contains lingua[0] %}
+              <a lang='{{lingua[0]}}'>{{lingua[1].language}}</a><br>
+              {% else %}
+              <span class="unavailable">{{lingua[1].language}}</span><br>
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+        </div>
+      </div>
+      <div class="dropdown quick-access"> <a> {{site.translations[page.lang].quickaccess}} </a>
+        <div class='quick-access dropdown-content'>
+          <!-- find out whether the remote-tracing guide exists in the current language; otherwise we will use English -->
+          {% assign remote_tracing = "/" | append: page.lang | append: "/coordination/remote-tracing/" %}
+          {% assign found = "0" %}
+          {% for post in site.categories['coordination'] %}
+            {% if post.permalink == remote_tracing %}
+              {% assign found = "1" %}
+              {% break %}
+            {% endif %}
+          {% endfor %}
+          {% if found == "1" %}
+            {% assign use_lang = page.lang %}
+          {% else %}
+            {% assign use_lang = "en" %}
+          {% endif %}
+          <!-- now build the menu proper -->
+          {% assign remote_tracing = "/" | append: use_lang | append: "/coordination/remote-tracing" %}
+          <a href="{{remote_tracing}}/#highways-howto">Highways - How to map</a><br>
+          <a href="{{remote_tracing}}/#residential-howto">landuse=residential - How to map</a><br>
+          <a href="{{remote_tracing}}/#buildings-howto">Buildings - How to map</a><br>
+          <hr>
+          <!-- find out which hot-tips exists in the current language; otherwise we will use English -->
+          {% assign local_tips = "" %}
+          {% assign remover = "/" | append: post.lang | append: "/hot-tips/" %}
+          {% for post in site.categories['hot-tips'] %}
+            {% if post.lang == page.lang %}
+              {% assign local_tip = post.permalink | remove: remover %}
+              {% assign local_tips = local_tips | append: local_tip | append: ' ' %}
+            {% endif %}
+          {% endfor %}
+          <!-- now build the menu proper -->
+          {% for post in site.categories['hot-tips'] %}
+            {% if post.lang == page.lang %}
+              <a href="{{post.permalink}}">{{post.title}}</a><br>
+            {% elsif post.lang == "en" %}
+              {% assign testee = post.permalink | remove: "/en/hot-tips/" %}
+              {% unless local_tips contains testee %}
+                <a href="{{post.permalink}}">{{post.title}}</a><br>
+              {% endunless %}
+            {% endif %}
+          {% endfor %}
+        </div>
+      </div>
+      <!-- small search bar does not appear on the front page -->
+      {% unless page.fronttitle or page.contributetitle%}
+      <form class='searchbox-default rounded'>
+        <span class='icon logo-search'></span>
+        <input id='search-field' type='text' name='search' class='default-value' />
+      </form>
+      {% endunless%}
+    </div>
+    <div id='header' class='cell12'>
+      <div class='marginL cell9 padAll'>
+        <div class='cell7 marginR'>
+           <span><a href='{{site.baseurl}}/{{page.lang}}' class="logo logo-learn"></a></span>
+           <span class='tagline'>{{site.translations[page.lang].tagline}}</span>
+        </div>
+        <a class='banner hide-mobile'>
+          <span class='{{page.lang}}'>{{site.translations[page.lang].contribute}}</span>
+        </a>
+        <a class='banner-mobile hide-desktop show-mobile' href='{{site.baseurl}}/{{page.lang}}/contribute/'>
+        </a>
+      </div>
+    </div>
+    <div id='content' class='cf'>
+      <div id='ads' class='marginL cell9 padAll'>
+        <div class='ad1 cell8 {% case page.lang %}{% when 'hr' %}no-capitalize{% else %}{% endcase %}'>
+          <a href='{{site.baseurl}}/{{page.lang}}/beginner'>
+            <span class='ad-title'>{{ page.begspan }}</span>
+            <span class='ad-txt'>{{ page.beg }}</span>
+            <span class='door'></span>
+          </a>
+        </div>
+        <div class='ad2 cell4 {% case page.lang %}{% when 'hr' %}no-capitalize{% else %}{% endcase %}'>
+          <a href='{{page.interspanlink}}'>
+            <span class='ad-title'>{{page.interspan}}</span>
+            <span class='ad-txt'>{{ page.inter }}</span>
+          </a>
+        </div>
+        <div class='ad3 cell4 {% case page.lang %}{% when 'hr' %}no-capitalize{% else %}{% endcase %}'>
+          <a href='{{page.advspanlink}}'>
+            <span class='ad-title'>{{page.advspan}}</span>
+            <span class='ad-txt'>{{page.adv}}</span>
+          </a>
+        </div>
+      </div>
+      <div class='marginL cell9 padAll'>
+        <form class='searchbox rounded'>
+          <span class='logo logo-search' style='margin-top: 0px;'></span>
+          <input id='search-field' type='text' name='search' class='default-value cell10'></input>
+        </form>
+      </div>
+      <div id='front' class='marginL cell9 padAll'>
+        <div class='front-text cell7 marginR'>
+          <h4 class='tagtitle'>{{ page.fronttitle }}</h4>
+          <p class='tagwords'>{{ page.frontintro }}</p>
+        </div>
+        <div class='faqbox cell4'>
+          <h4>{{page.faq}}</h4>
+          <ul class='faq'>
+            <li><a href='{{site.baseurl}}/{{page.lang}}/beginner/introduction/'>{{page.faqA}}</a></li>
+            <li><a href='{{site.baseurl}}/{{page.lang}}/beginner/start-osm/#beginning-osm-create-an-openstreetmap-account'>{{page.faqC}}</a></li>
+            <li><a href='{{site.baseurl}}/{{page.lang}}/beginner/moving-forward/'>{{page.faqD}}</a></li>
+            <li><a href='{{site.baseurl}}/{{page.lang}}/contribute/'>{{page.faqB}}</a></li>
+        </div>
+      </div>
+      <script>
+      // detect if ad is overflowing
+      var spanTitle = $('span.ad-title','#ads');
+        $.each(spanTitle, function(i,el){
+        var titleParent = el.parentElement,
+            titleSister = el.nextElementSibling;
+        var titleHeight = el.offsetHeight,
+            txtHeight = titleSister.offsetHeight,
+            adHeight = titleParent.offsetHeight;
+        if (titleHeight + txtHeight > adHeight) {
+          titleSister.style.display = 'none'
+        } 
+      });
+      // format the search bar on the front
+      var input = $(".searchbox input[type=text]"),
+        inputTitle = "{{page.searchtext}}"; //needs tranlation
+        input.val(inputTitle);
+      
+      input.blur(function() {
+      if (input.val() === "") {
+          input.val(inputTitle); // restore default text
+          input.addClass("default-value");
+      }
+      }).focus(function() {
+        if (input.val() === inputTitle) {
+            input.val("");
+            input.removeClass("default-value");
+        }
+      });
+      </script>
+    </div>
+    <footer id='footer' class='fillG cell12'>
+      <ul class='contact marginL marginR cell3 padAll'>
+        <li><a class='email' href="mailto:learnosm@hotosm.org">learnosm@hotosm.org</a></li>
+        <li><a class='twitter' href="https://twitter.com/learnosm">@learnOSM</a></li>
+        <li><a class='github' href='https://github.com/hotosm/learnosm'> Hosted on Github</a></li>
+        <li>
+          <a rel="license" class="license" href="https://creativecommons.org/publicdomain/zero/1.0/">
+            <img src="https://i.creativecommons.org/p/zero/1.0/80x15.png" alt="CC0" />
+          </a>
+      </li>
+      </ul>
+      <div class='sponsors cell6 padAll'>
+        <span>Official <a href='https://hot.openstreetmap.org/' target='_blank'>HOT OSM</a> learning materials</span>
+        <a class='logo logo-hot left' href='https://hot.openstreetmap.org/' target='_blank'></a>
+        <a class='logo logo-ausaid left' href='https://en.wikipedia.org/wiki/Australian_Aid' target='_blank'></a>
+        <a class='logo logo-bnpb left' href='https://www.bnpb.go.id/' target='_blank'></a>
+      </div>
+    </footer>
+  </div>
+  <div id="optout-form"></div>
+  </body>
+  <script>
+  // autocomplete search with all-translation json
+    $.getJSON("{{site.baseurl}}/all-translation.json",function(data){
+      console.log(data);
+      var lang = "{{page.lang}}";
+      data.forEach(function(o){
+        if (o.lang === lang){
+          var destination;
+          $( "#search-field" ).autocomplete({
+           autoFocus: true, // highlight the first search result in dropdown
+           delay: 0,
+           source: o.chapters,
+           select: function(event, ui) {
+             destination = '{{site.baseurl}}' + ui.item.url;
+             window.location = destination;
+           }
+          });
+        }
+      })
+  });
+  </script>
+</html>

--- a/style.css
+++ b/style.css
@@ -201,7 +201,7 @@ small {
 }
 
 img {
-  display: span;
+  display: block;
   max-width:480px;
   background: #fff;
   padding:3px;
@@ -519,7 +519,7 @@ a.license {
   top: 0;
 }
 .doc-nav.bottom {
-  positon:absolute;
+  position:absolute;
   bottom: 200px;
 }
 .doc-nav ul li a {
@@ -587,20 +587,21 @@ a.license {
   border-top: 4px solid   #f0f0f0;
   border-left: 4px solid  #f0f0f0;
   border-right: 4px solid #f0f0f0;
-
-  .doc .cover span:before {
-    content:'';
-  }
+}
+ 
+.doc .cover span:before {
+  content:'';
+}
 
 /* Ideas for "other guide" navigation menu */
-  .doc .title.other {
-    background: #efe;
-  }
+.doc .title.other {
+  background: #efe;
+}
 
-  .doc .title.cover.other,
-  .doc .title.cover.other:hover,
-  .doc .title.cover.other.active {
-    background: #dfd;
+.doc .title.cover.other,
+.doc .title.cover.other:hover,
+.doc .title.cover.other.active {
+  background: #dfd;
 }
 
 
@@ -719,7 +720,7 @@ a.license {
 
 /* Mobile and tablet Layout
 ------------------------------------------------------- */
-@media only screen and (max-width: 770px) {
+@media screen and (max-width: 770px) {
   .cell1,
   .cell2,
   .cell3,
@@ -731,7 +732,7 @@ a.license {
   .cell9,
   .cell10,
   .cell11,
-  .cell12 { width:100%; max-width:100%; }
+  .cell12 { width:100%; max-width:100%; float: none; }
   .marginL { margin-left:0%; }
   .marginR { margin-right: 0%;}
   .padAll,.padTB,.padLR { padding: 0px;}
@@ -740,7 +741,7 @@ a.license {
   .show-mobile { display: block;}
   h4 {margin:10px 0;}
   #header {background: none;}
-    #header > * {margin:0 -20px 0 20px;}
+  #header > * {margin:0 -20px 0 20px;}
   #ads a {border-radius:0;}
   #ads .ad1, #ads .ad2, #ads .ad3 {height:auto;}
   #ads .ad1 a, #ads .ad2 a, #ads .ad3 a {margin:0;}
@@ -759,7 +760,7 @@ a.license {
   #content {padding-bottom:50px;}
   #footer {padding-left:15px;}
   a.license {left:250px;top:10px;}
-  }
+}
 
 .no-capitalize a {
   text-transform: none !important;

--- a/style.css
+++ b/style.css
@@ -195,7 +195,7 @@ strong {font-weight:700;}
 .doc li a, .doc p a {color: #79bc5f;}
 .doc-nav-secondary li {padding-left:60px;}
 
-small {
+footer {
   font-size:12px;
   line-height:16px;
 }
@@ -322,7 +322,8 @@ table {
   background: #fff url(./img/dot.png) repeat-x bottom;
 }
 .banner, .banner-mobile {
-  position:absolute;
+  position: fixed;
+  z-index: 999;
   right:0;
   background: transparent url(./img/sprite.png)  -324px 0px;
   width: 60px;
@@ -437,9 +438,9 @@ table {
     .github:hover:before {background-position:-80px -178px;}
 .sponsors span {display:block;}
   .sponsors span a {color:#fc3f51;}
+
 a.license {
-  position:absolute;
-  left:360px;
+  display: inline;
   }
 .sponsors a.logo {margin-top:30px;}
   .sponsors a.logo-hot {background-position:0 0;}
@@ -540,7 +541,6 @@ input.default-value {
 /* doc nav */
 .doc-nav {
   position:absolute;
-  padding-top: 30px;
 }
 .doc-nav.fixed {
   position:fixed;

--- a/style.css
+++ b/style.css
@@ -787,6 +787,7 @@ input.default-value {
   #content {padding-bottom:30px;}
   #footer { padding-left:15px; width: 98%; height: 16rem; }
   a.license {left:250px;top:10px;}
+  .doc-nav.bottom { position: relative; }
 }
 
 .no-capitalize a {

--- a/style.css
+++ b/style.css
@@ -277,15 +277,12 @@ table {
   position:relative;
 }
 #content {
-  padding-bottom:180px;
+  padding-bottom:60px;
   clear: both;
 }
 #footer {
   width:100%;
-  position:absolute;
   padding-top:30px;
-  bottom:0;
-  left:0;
 }
 .dropdown {
   padding:6px 20px;
@@ -374,9 +371,9 @@ table {
   font-weight:700;
 }
 #ads a:hover {color:#101010;}
-#ads .ad1 a {height:180px;background:#92d07a;margin-right:20px;}
+#ads .ad1 a {height:204px;background:#92d07a;margin-right:20px;}
 #ads .ad2 a {height:80px; background:#ffd429;margin-bottom:20px;}
-#ads .ad3 a {height:60px; background:#7abeff;}
+#ads .ad3 a {height:84px; background:#7abeff;}
   #ads .ad2 a:hover {background:#f0ca42;}
   #ads .ad3 a:hover {background:#90c4f5;}
   #ads .ad1 span.door {
@@ -777,7 +774,6 @@ input.default-value {
   #ads .ad1, #ads .ad2, #ads .ad3 {height:auto;}
   #ads .ad1 a, #ads .ad2 a, #ads .ad3 a {margin:0;}
   /*#ads .ad1 span.door {margin-top:-60px;}*/
-  #footer {position:relative;}
   .searchbox-default {padding-left:10px;float:right;}
   .searchbox {border-radius:0px; border:8px solid #f0f0f0;}
   .searchbox input {width:200px;}
@@ -788,8 +784,8 @@ input.default-value {
   img {max-width:300px;}
   .doc h1, .doc p, .doc ul, .doc ol {margin-left:15px;width:95%;}
   .doc h2, .doc h3 {margin-left:30px;width:95%;}
-  #content {padding-bottom:50px;}
-  #footer {padding-left:15px;}
+  #content {padding-bottom:30px;}
+  #footer { padding-left:15px; width: 98%; height: 16rem; }
   a.license {left:250px;top:10px;}
 }
 

--- a/style.css
+++ b/style.css
@@ -273,6 +273,8 @@ table {
 }
 
 #wrapper {
+  display: flex;
+  flex-direction: column;
   min-height:100%;
   position:relative;
 }
@@ -302,7 +304,7 @@ table {
   display:block;
   position:absolute;
   background-color:#f0f0f0;
-  z-index:1;
+  z-index: 999;
 }
 .dropdown-content.language-switcher { width: 20ch; outline: 2px solid #79bc5f; }
 .dropdown-content.quick-access { width: 35ch; outline: 2px solid #79bc5f; }
@@ -320,7 +322,7 @@ table {
 }
 .banner, .banner-mobile {
   position: fixed;
-  z-index: 999;
+  z-index: 99;
   right:0;
   background: transparent url(./img/sprite.png)  -324px 0px;
   width: 60px;
@@ -392,7 +394,7 @@ table {
   background:url(./img/sprite.png) no-repeat;
   width:16px;
   height:20px;
-  margin-right:20px;
+  margin-right:10px;
   }
 .logo {
   display:block;
@@ -463,8 +465,7 @@ a.license {
 
 .logo-search {
   float:left;
-  margin-left:3px;
-  margin-top: 4px;
+  margin: 4px 10px 10px 3px;
   width: 30px;
   height: 28px;
   background-position:-152px -150px;
@@ -476,14 +477,14 @@ input.default-value {
 }
 .searchbox-default {
   padding-right: 16px;
-  float:right;
+  float:left;
 }
 .searchbox-default input {
   border: none;
   margin-top: 9px;
   background-color:#ffffff;
   height: 20px;
-  width: 132px;
+  width: 280px;
 }
 
 .searchbox-default input:focus {
@@ -775,8 +776,8 @@ input.default-value {
   #ads .ad1 a, #ads .ad2 a, #ads .ad3 a {margin:0;}
   /*#ads .ad1 span.door {margin-top:-60px;}*/
   .searchbox-default {padding-left:10px;float:right;}
+  .searchbox-default input { width: 170px; outline: 2px solid #f0f0f0; }
   .searchbox {border-radius:0px; border:8px solid #f0f0f0;}
-  .searchbox input {width:200px;}
   .doc-nav,.doc-nav.fixed {position:relative;margin-bottom:20px;}
   .doc-main {margin-left:0%}
   .feedback {padding-top:20px;padding-left:15px;}
@@ -788,6 +789,10 @@ input.default-value {
   #footer { padding-left:15px; width: 98%; height: 16rem; }
   a.license {left:250px;top:10px;}
   .doc-nav.bottom { position: relative; }
+}
+
+@media screen and (max-width: 667px) {
+  .searchbox-default {padding-left:10px;float:left;}
 }
 
 .no-capitalize a {

--- a/style.css
+++ b/style.css
@@ -292,6 +292,11 @@ table {
   position:relative;
   display:inline-block;
 }
+
+.dropdown:hover {
+  cursor: pointer;
+}
+
 .dropdown-content {
   display:none;
 }
@@ -302,8 +307,8 @@ table {
   background-color:#f0f0f0;
   z-index:1;
 }
-.dropdown-content.language-switcher { width: 20ch; }
-.dropdown-content.quick-access { width: 35ch; }
+.dropdown-content.language-switcher { width: 20ch; outline: 2px solid #79bc5f; }
+.dropdown-content.quick-access { width: 35ch; outline: 2px solid #79bc5f; }
 .language-switcher a.active {
   color: #79bc5f;
   text-decoration: none;
@@ -315,33 +320,37 @@ table {
 #header {
   padding:20px 0px;
   background: #fff url(./img/dot.png) repeat-x bottom;
-  }
+}
 .banner, .banner-mobile {
-    position:absolute;
-    right:0;
-    background: transparent url(./img/sprite.png)  -324px 0px;
-    width: 60px;
-    height: 76px;
-    transition: all 200ms linear;
-    -moz-transition: all 200ms linear;
-    -webkit-transition: all 200ms linear;
-    -o-transition: all 200ms linear;
-  }
-  .banner span {
-    display:none;
-    color: #79bc5f;
-    text-transform:uppercase;
-    font-size:12px;
-    font-weight:700;
-    padding:2px 18px 0 60px;
-  }
-  .banner span.en,.banner span.jp {padding-top:14px;}
-  .banner.active {
-    width:188px;
-  }
-  .banner span.active {
-    display:block;
-  }
+  position:absolute;
+  right:0;
+  background: transparent url(./img/sprite.png)  -324px 0px;
+  width: 60px;
+  height: 76px;
+  transition: all 200ms linear;
+  -moz-transition: all 200ms linear;
+  -webkit-transition: all 200ms linear;
+  -o-transition: all 200ms linear;
+}
+
+.banner span {
+  display:none;
+  color: #79bc5f;
+  text-transform:uppercase;
+  font-size:12px;
+  font-weight:700;
+  padding:2px 18px 0 60px;
+}
+
+.banner span.en,.banner span.jp {padding-top:14px;}
+.banner.active {
+  width:188px;
+}
+
+.banner span.active {
+  display:block;
+}
+
 .ourguides span{
   font-weight:700;
 }
@@ -401,6 +410,10 @@ table {
     background-position:0px -115px;
     }
 
+#front {
+  margin-top: 16px;
+}
+
 /* footer */
 .license img {
   padding:0;
@@ -437,33 +450,48 @@ a.license {
   height:32px;
   border:4px solid #f0f0f0;
   }
-  .searchbox input {
-    border:none;
-    padding:4px 0px 4px 20px;
-    font-size:16px;
-    font-family:'Source Sans Pro',sans-serif;
-    background-color: #ffffff;
-  }
-  .logo-search {
-    float:left;
-    margin-left:3px;
-    width: 30px;
-    height: 28px;
-    background-position:-152px -150px;
-  }
-  input.default-value {
-    color:#ccc !important;
-    font-style: italic;
-  }
+
+.searchbox input {
+  border:none;
+  padding:4px 0px 4px 20px;
+  font-size:16px;
+  font-family:'Source Sans Pro',sans-serif;
+  background-color: #ffffff;
+}
+
+.searchbox input:focus {
+  outline: 2px solid #79bc5f;
+}
+
+.logo-search {
+  float:left;
+  margin-left:3px;
+  margin-top: 4px;
+  width: 30px;
+  height: 28px;
+  background-position:-152px -150px;
+}
+
+input.default-value {
+  color:#ccc !important;
+  font-style: italic;
+}
 .searchbox-default {
-  padding-right:08.3333%;
+  padding-right: 16px;
   float:right;
 }
 .searchbox-default input {
-  border:none;
-  margin-top:6px;
-  background-color: #ffffff;
+  border: none;
+  margin-top: 9px;
+  background-color:#ffffff;
+  height: 20px;
+  width: 132px;
 }
+
+.searchbox-default input:focus {
+  outline: 2px solid #79bc5f;
+}
+
 /* overriding default jquery ui css for autocomplete */
 .ui-corner-all {
   -moz-border-radius:   0px !important;
@@ -721,6 +749,9 @@ a.license {
 /* Mobile and tablet Layout
 ------------------------------------------------------- */
 @media screen and (max-width: 770px) {
+  #wrapper {
+    padding: .9rem;
+  }
   .cell1,
   .cell2,
   .cell3,
@@ -747,7 +778,7 @@ a.license {
   #ads .ad1 a, #ads .ad2 a, #ads .ad3 a {margin:0;}
   /*#ads .ad1 span.door {margin-top:-60px;}*/
   #footer {position:relative;}
-  .searchbox-default {padding-left:10px;float:left;}
+  .searchbox-default {padding-left:10px;float:right;}
   .searchbox {border-radius:0px; border:8px solid #f0f0f0;}
   .searchbox input {width:200px;}
   .doc-nav,.doc-nav.fixed {position:relative;margin-bottom:20px;}


### PR DESCRIPTION
Hi there!

Looks like a lot of the responsive design was already in the codebase but was obscured by some invalid CSS in `style.css`. This PR addresses the discussion in #595 

I've fixed a number of things, including:

- the homepage
- the mobile top banner
- the mobile doc-nav
- the footer
- fixed the `z-index` of the side banner
- added some clarifying style to the language and quick access menus (including a `cursor: pointer`)
- adding `:focus` highlighting for the search box

Here's a few screen grabs:

<img width="710" alt="Screen Shot 2020-02-11 at 1 02 07 PM" src="https://user-images.githubusercontent.com/158590/74279782-d0537a00-4cd8-11ea-9e01-c957ed18fae8.png">

---

<img width="413" alt="Screen Shot 2020-02-11 at 12 56 06 PM" src="https://user-images.githubusercontent.com/158590/74273955-84033c80-4cce-11ea-86bd-29403dc2dc8f.png">

---

<img width="374" alt="Screen Shot 2020-02-11 at 12 56 27 PM" src="https://user-images.githubusercontent.com/158590/74273956-849bd300-4cce-11ea-80f8-22121f3986f3.png">

---

<img width="949" alt="Screen Shot 2020-02-11 at 12 52 11 PM" src="https://user-images.githubusercontent.com/158590/74273949-806fb580-4cce-11ea-8c64-d4de78ac8e28.png">
