### PR TITLE
Update Matomo tracking to v3 - set user consent

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,7 +31,7 @@
     <script src="{{ site.baseurl }}/site.js"></script>
     <!-- Matomo -->
     <script type="application/javascript">var site_id="3";</script>
-    <script type="application/javascript" src="https://cdn.hotosm.org/tracking-v1.js"></script>
+    <script type="application/javascript" src="https://cdn.hotosm.org/tracking-v3.js"></script>
     <!-- End Matomo -->
   </head>
   <body>


### PR DESCRIPTION
Updating to the v3 will improve the tracking by remembering the tracking consent for future sessions. 