### PR TITLE
try to simplify instructions

### DIFF
--- a/_posts/en/0200-12-23-id-editor_en.md
+++ b/_posts/en/0200-12-23-id-editor_en.md
@@ -27,7 +27,8 @@ Starting the iD Editor
 -	Open your Internet browser, and go to the OpenStreetMap website at [http://www.openstreetmap.org](http://www.openstreetmap.org).  
 -	**Login** using your OpenStreetMap account  
 -	Pan and zoom the map to the area that you wish to edit. You can pan by holding the left mouse button and dragging the map to your desired area.  
--	Click on the small arrow next to **Edit**. Then click **Edit with iD (in-browser editor)**.  
+-	Click the **Edit** button.
+-	In case that you changed default editior - click on the small arrow next to **Edit**. Then click **Edit with iD (in-browser editor)**.  
 
 ![image1][]
 


### PR DESCRIPTION
not 100% sure, maybe old one was good? Maybe this 

> In case that you changed default editior - click on the small arrow next to **Edit** Then click **Edit with iD (in-browser editor)**. 

should be removed?

It may  be also useful to update image, maybe without OS styling