### PR TITLE
Fix typo

### DIFF
--- a/_posts/en/0200-12-23-id-editor_en.md
+++ b/_posts/en/0200-12-23-id-editor_en.md
@@ -156,7 +156,7 @@ When (and if) you want to save your edits to OpenStreetMap, click the **Save** b
 
 - Enter a comment about your edits and click **Save**.  
 
-> If you have edited the same feature (point, way or area) at the same time as another person was editing it, you will receive a warning that your edits cannot be uploaded until you have resolved the **conflicts** - choose whose edits to accept & upload your changes. *Resolving conflicts often involves accepting the other persons edits, in which case you will probably wish to return to the feature in question and edit again (**this time save soon after the edit to try to avoid a conflict again!**).*
+> If you have edited the same feature (point, way or area) at the same time as another person was editing it, you will receive a warning that your edits cannot be uploaded until you have resolved the **conflicts** - choose whose edits to accept & upload your changes. *Resolving conflicts often involves accepting the other person's edits, in which case you will probably wish to return to the feature in question and edit again (**this time save soon after the edit to try to avoid a conflict again!**).*
 
 Additional Information and Custom Tags
 ---------------------------------------


### PR DESCRIPTION
Added missing apostrophe in Saxon genitive. A minor and, perhaps, nitpicky change :)