### PR TITLE
fix: upgrade http to https links in English articles

### DIFF
--- a/_posts/en/0100-01-01-contribute_en.md
+++ b/_posts/en/0100-01-01-contribute_en.md
@@ -11,4 +11,4 @@ startC: "Improve Images - in your language!"
 startD: "Report issues and contribute"
 nosearch: true
 ---
-This guide is created and maintained by the [OpenStreetMap](http://www.openstreetmap.org/) and [Humanitarian OpenStreetMap](http://hotosm.org/) community. You can help us improve this guide by simply sending your feedback or by contributing directly to it via [Github](http://github.com/hotosm/learnosm).
+This guide is created and maintained by the [OpenStreetMap](https://www.openstreetmap.org/) and [Humanitarian OpenStreetMap](https://hotosm.org/) community. You can help us improve this guide by simply sending your feedback or by contributing directly to it via [Github](https://github.com/hotosm/learnosm).

--- a/_posts/en/0150-06-20-images-translator_en.md
+++ b/_posts/en/0150-06-20-images-translator_en.md
@@ -105,15 +105,15 @@ Go through each of the images that you have uploaded a new image for, updating t
 Finally - the images will display within a day or two
 ------------------------------------------------------
 
-One of the site admin's will need to merge your pull request, and then your images will appear on the staging site at <http://nick-tallguy.github.io/en/>  
+One of the site admin's will need to merge your pull request, and then your images will appear on the staging site at <https://nick-tallguy.github.io/en/>  
 
-And once everyone is happy with the images and links, the changed files and new images will be added to <http://learnosm.org/en/>.  
+And once everyone is happy with the images and links, the changed files and new images will be added to <https://learnosm.org/en/>.  
 
 Any problems, please make contact   
 -----------------------------------
 
 - send an email to <learnosm@hotosm.org>  
-- send an email from the contribute section of <http://nick-tallguy.github.io/en/>, or  
+- send an email from the contribute section of <https://nick-tallguy.github.io/en/>, or  
 - raise an issue on Github at <https://github.com/hotosm/learnosm/issues>, or  
 - raise an issue on Transifex  
 

--- a/_posts/en/0150-09-20-translator_en.md
+++ b/_posts/en/0150-09-20-translator_en.md
@@ -13,7 +13,7 @@ Translators using Transifex - instructions
 - TOC
 {:toc}
 
-This guide is an updated version of the guides currently located at <https://github.com/Nick-Tallguy/Nick-Tallguy.github.io/wiki/Translator-instructions-for-Transifex>. When these instructions are complete they will be added to the site at <http://learnosm.org/en/> and made to appear in all available languages.  
+This guide is an updated version of the guides currently located at <https://github.com/Nick-Tallguy/Nick-Tallguy.github.io/wiki/Translator-instructions-for-Transifex>. When these instructions are complete they will be added to the site at <https://learnosm.org/en/> and made to appear in all available languages.  
 
 Transifex
 ------------
@@ -24,12 +24,12 @@ The Two sites
 -------------
 
 ### LearnOSM
-The main LearnOSM site is at <http://learnosm.org/> and this is the site we are aiming to update. If you search on the internet, this is the site you will find. The modules on this site are all at 100% completion, but there are a few shortcuts in place to make sure that visitors do not get .404 errors.   
+The main LearnOSM site is at <https://learnosm.org/> and this is the site we are aiming to update. If you search on the internet, this is the site you will find. The modules on this site are all at 100% completion, but there are a few shortcuts in place to make sure that visitors do not get .404 errors.   
 
 There are also some translations on this site which were created before we started using Transifex. However, these modules are gradually becoming out of date, and we would like them replaced with new translations provided by you using Transifex.  
 
 ### The Staging or testing site
-We have a second site <http://nick-tallguy.github.io/> which we use for testing purposes, and which is used to allow translators to check on their progress and see how the site will appear in their language.  
+We have a second site <https://nick-tallguy.github.io/> which we use for testing purposes, and which is used to allow translators to check on their progress and see how the site will appear in their language.  
 
 When we are testing things out they will appear on the staging site - but sometimes they never appear on the main LearnOSM site - not all ideas are good! If we are considering altering the layout of pages, changing the margins, or otherwise altering the site it will appear here first. Modules which are being developed are also created on the staging site and reviewed before being placed on the main site, and into Transifex for your translation.  
 
@@ -215,7 +215,7 @@ The \> remains, **Reviewed** is translated, and the date is put into a format th
 
       Year-month-day of month  
 
- > Don't forget you can review your translations on <http://nick-tallguy.github.io/en/> - this site updates roughly once a day.  
+ > Don't forget you can review your translations on <https://nick-tallguy.github.io/en/> - this site updates roughly once a day.  
 
 
 ## 0200-12-29-introduction  
@@ -262,7 +262,7 @@ Any problems, please make contact
 -----------------------------------
 
 - send an email to <learnosm@hotosm.org>  
-- send an email from the contribute section of <http://nick-tallguy.github.io/en/>, or  
+- send an email from the contribute section of <https://nick-tallguy.github.io/en/>, or  
 - raise an issue on Github at <https://github.com/hotosm/learnosm/issues>, or  
 - raise an issue on Transifex  
 
@@ -275,7 +275,7 @@ Links to Transifex guides
 
 ## Below this line is waiting for review - the 'old instructions'
 
-You are viewing these instructions on a 'staging site', but the information is transferred frequently between this site and the main LearnOSM site. The [current staging site can be viewed here](http://nick-tallguy.github.io/en/). By using this staging site as an interim, we can check that we haven't lost any formatting marks in the translation process. Don't worry about losing the formatting - we'll put it back in afterwards, as long as we can work out where it goes.
+You are viewing these instructions on a 'staging site', but the information is transferred frequently between this site and the main LearnOSM site. The [current staging site can be viewed here](https://nick-tallguy.github.io/en/). By using this staging site as an interim, we can check that we haven't lost any formatting marks in the translation process. Don't worry about losing the formatting - we'll put it back in afterwards, as long as we can work out where it goes.
 
 LearnOSM has been using Transifex for a while, but we're still learning! Feedback is appreciated. At present we're not sure how many formatting marks will actually appear in the file that you view, or in the file which we download at the end of the process, so this guide is written on a very provisional basis.
 
@@ -283,7 +283,7 @@ There are limitations on how many languages we can actually display on LearnOSM.
 
 ## Priorities  
 
-We are carrying out a review of any guide before uploading it to Transifex, and you will see the date of that review at the head of the file. Some of these guides may already have been translated, but we can only offer the guide for translation from the latest version, which will be the one with the review date. It may be that only the context has altered where some guides have moved to different sections of LearnOSM. As there is no way for us to indicate that a particular module does not need translating in a particular language, you may wish to compare the modules against what is already on [LearnOSM](http://nick-tallguy.github.io/en/), in case it has already been translated. In a perfect world we would like each module translated, and another person to verify the translation - this is possible with the Transifex system, but only if enough people provide translations!
+We are carrying out a review of any guide before uploading it to Transifex, and you will see the date of that review at the head of the file. Some of these guides may already have been translated, but we can only offer the guide for translation from the latest version, which will be the one with the review date. It may be that only the context has altered where some guides have moved to different sections of LearnOSM. As there is no way for us to indicate that a particular module does not need translating in a particular language, you may wish to compare the modules against what is already on [LearnOSM](https://nick-tallguy.github.io/en/), in case it has already been translated. In a perfect world we would like each module translated, and another person to verify the translation - this is possible with the Transifex system, but only if enough people provide translations!
 
 
 

--- a/_posts/en/0150-10-20-style_en.md
+++ b/_posts/en/0150-10-20-style_en.md
@@ -162,7 +162,7 @@ Refer to Markdown post guidelines.
 
     https://github.com/hotosm/learnosm/wiki/Markdown-post-guidelines
 
-    http://daringfireball.net/projects/markdown/syntax
+    https://daringfireball.net/projects/markdown/syntax
 
 
 Attribution of images and screen-shots
@@ -189,6 +189,6 @@ Images should be labeled with numbers and arrows pointing to the specific parts 
 References
 ==============
  * GNOME Style Guide - https://developer.gnome.org/gdp-style-guide/stable/
- * Geoserver Style Guide - http://docs.geoserver.org/latest/en/docguide/style.html
- * Documenting Python - http://docs.python.org/devguide/documenting.html
+ * Geoserver Style Guide - https://docs.geoserver.org/latest/en/docguide/style.html
+ * Documenting Python - https://docs.python.org/devguide/documenting.html
  * GH Issue on the topic - hotosm/learnosm#82

--- a/_posts/en/0170-12-20-resources_en.md
+++ b/_posts/en/0170-12-20-resources_en.md
@@ -13,14 +13,14 @@ category: resources
 
 This is a commented list of pointers to other websites which we consider useful. All links have been verified to work when this document was last reviewed.
 
-  * [Maptime list of links on mapping and related cartographic topics](http://maptime.io/lessons-resources/) A comprehensive list of links, not just about OpenStreetMap but also covers visualization, map creation and web mapping
+  * [Maptime list of links on mapping and related cartographic topics](https://maptime.io/lessons-resources/) A comprehensive list of links, not just about OpenStreetMap but also covers visualization, map creation and web mapping
 
 
 ## Editing
 
 ### iD
 
-  * [iD's integrated tutorial](http://www.openstreetmap.org/edit?editor=id#walkthrough=true) An interactive tutorial on using iD as part of the software
+  * [iD's integrated tutorial](https://www.openstreetmap.org/edit?editor=id#walkthrough=true) An interactive tutorial on using iD as part of the software
   * [presentation slides covering the contents of our guide](/files/iD-editor-training.pptx) good material if you would like to give an introduction about iD e.g. at a mapathon
   * [HOT Video Tutorials](https://www.youtube.com/playlist?list=PLb9506_-6FMHULD9iDUAh-4qpxKdVspnD) A collection of instructive videos mostly centered around mapping with iD and JOSM
   * [Video tutorials on iD](https://www.sjtdelfs.de/wordpress/?page_id=84) Some very short videos explaining how to accomplish common tasks
@@ -28,8 +28,8 @@ This is a commented list of pointers to other websites which we consider useful.
 
 ## Mapathons and similar events
 
-  * [Wiki entry about Missing Maps Mapathons](http://wiki.openstreetmap.org/wiki/Missing_Maps_mapathons) nearly a checklist giving you an idea what to consider if you want to organize a mapathon; although targeted towards Missing Maps most of it applies to mapathons in general
-  * [Wiki entry about Missing Maps Mapathons in a University setting](http://wiki.openstreetmap.org/wiki/Missing_Maps_mapathons:_for_students_and_universities) nearly the same document as the previous one but with specific hints if organized at a university
+  * [Wiki entry about Missing Maps Mapathons](https://wiki.openstreetmap.org/wiki/Missing_Maps_mapathons) nearly a checklist giving you an idea what to consider if you want to organize a mapathon; although targeted towards Missing Maps most of it applies to mapathons in general
+  * [Wiki entry about Missing Maps Mapathons in a University setting](https://wiki.openstreetmap.org/wiki/Missing_Maps_mapathons:_for_students_and_universities) nearly the same document as the previous one but with specific hints if organized at a university
   * [developmentSEED guide for Mapathons](https://developmentseed.org/blog/2015/06/07/organizing-mapathons/) This document is based on a talk at a State of the Map conference about how to organize and run a mapathon
 
 ### Checklists for planning
@@ -44,4 +44,4 @@ This is a commented list of pointers to other websites which we consider useful.
 
   * [Wiki entry on MapCraft](https://wiki.openstreetmap.org/wiki/MapCraft) A simple open-source coordination tool. The wiki says that it is no longer actively maintained
   * [Real-time progress on OpenStreetMap](https://github.com/osmlab/show-me-the-way) The readme page on github explains how to filter the display so that you do not see progress worldwide
-  * [Who is around me ](http://resultmaps.neis-one.org/oooc) map display about mappers who recently contributed in an area
+  * [Who is around me ](https://resultmaps.neis-one.org/oooc) map display about mappers who recently contributed in an area

--- a/_posts/en/0200-12-03-moving-forward_en.md
+++ b/_posts/en/0200-12-03-moving-forward_en.md
@@ -20,13 +20,13 @@ At the end of the chapter on the iD editor you heard about the differences betwe
 
 So far, all the edits we added to the map were based on background imagery. But you can collect a wealth of information while walking or driving around. The [section on mobile mapping](/en/mobile-mapping/) explains how to collect information with different GPS-based devices or using specially designed printouts. It also reviews a number of OpenStreetMap-related applications for mobile devices.  
 
-OpenStreetMap is a collaborative effort and we hope that you will be part of it. Some of these efforts are devoted to humanitarian relief under the auspices of the [Humanitarian OSM Team](http://hotosm.org). If you would like to help HOT on the occasion of a disaster such as the Nepal earthquake please see the [section on coordination](/en/coordination/). It deals with the tools which make sure that many people can work together on a relatively small area in a consistent manner. It also contains guidance on some typical tasks you will frequently encounter when joining these efforts.  
+OpenStreetMap is a collaborative effort and we hope that you will be part of it. Some of these efforts are devoted to humanitarian relief under the auspices of the [Humanitarian OSM Team](https://hotosm.org). If you would like to help HOT on the occasion of a disaster such as the Nepal earthquake please see the [section on coordination](/en/coordination/). It deals with the tools which make sure that many people can work together on a relatively small area in a consistent manner. It also contains guidance on some typical tasks you will frequently encounter when joining these efforts.  
 
 
 Learn More
 ----------
 
-There is a lot of information about OpenStreetMap available at [wiki.openstreetmap.org](http://wiki.openstreetmap.org/). Here you can find information about other projects that are related to OpenStreetMap, and documents and tutorials that can help you learn more about OSM.  
+There is a lot of information about OpenStreetMap available at [wiki.openstreetmap.org](https://wiki.openstreetmap.org/). Here you can find information about other projects that are related to OpenStreetMap, and documents and tutorials that can help you learn more about OSM.  
 
 ![Wiki][]
 
@@ -37,7 +37,7 @@ Mailing List
 
 The best way to get connected to the OpenStreetMap user community is to join your local mailing list. Many people sign up, using their email accounts to the OSM mailing list. Once you are on the list, you can send an email to the group if you have a question or want to talk about OpenStreetMap.  
 
-To sign up for your country's mailing list, open your internet browser and go to [lists.openstreetmap.org](http://lists.openstreetmap.org/).  
+To sign up for your country's mailing list, open your internet browser and go to [lists.openstreetmap.org](https://lists.openstreetmap.org/).  
 
 ![Mailing list][]
 

--- a/_posts/en/0200-12-23-id-editor_en.md
+++ b/_posts/en/0200-12-23-id-editor_en.md
@@ -24,7 +24,7 @@ Starting the iD Editor
 ----------------------
 
 -	The iD editor requires an active connection to the Internet.  
--	Open your Internet browser, and go to the OpenStreetMap website at [http://www.openstreetmap.org](http://www.openstreetmap.org).  
+-	Open your Internet browser, and go to the OpenStreetMap website at [https://www.openstreetmap.org](https://www.openstreetmap.org).  
 -	**Login** using your OpenStreetMap account  
 -	Pan and zoom the map to the area that you wish to edit. You can pan by holding the left mouse button and dragging the map to your desired area. 
 -	Click on the small arrow next to **Edit**. Then click **Edit with iD (in-browser editor)**
@@ -63,7 +63,7 @@ You can **change the background layer** based on your desired tile provider (the
 
 You can add your own map tiles by clicking on **Custom**. For example, if you want to **add a Field Paper** [^fieldpaper], click **Custom** then click on the magnifying glass (search) icon to open the following window:-  
 ![image17][]   
-and enter your **FieldPaper snapshot URL**, which will be something like this: <http://fieldpapers.org/snapshot.php?id=cqhmf2v9#18/37.80593/-122.22715>   
+and enter your **FieldPaper snapshot URL**, which will be something like this: <https://fieldpapers.org/snapshot.php?id=cqhmf2v9#18/37.80593/-122.22715>   
 To **display GPS tracks from your computer** (GPX format), drag and drop the GPX file into iD editor.  
 To enable **OpenStreetMap GPS traces** click on the box. In the image below, public GPS traces are shown in various colors, indicating the direction of travel.  
 ![osm gps traces][]  

--- a/_posts/en/0200-12-27-start-osm_en.md
+++ b/_posts/en/0200-12-27-start-osm_en.md
@@ -20,7 +20,7 @@ Visit the OpenStreetMap Website
 
 -   Open your web browser.
 -   In the address bar at the top of the window, enter the following and press Enter:
-    [www.openstreetmap.org](http://www.openstreetmap.org/)
+    [www.openstreetmap.org](https://www.openstreetmap.org/)
 -   When the page has finished loading, you should see something like this:
 
     ![OpenStreetMap website with some main functions listed][]
@@ -102,7 +102,7 @@ Adding Your First Points
 -   If you do click Save, you will be asked to provide a description of your changes.  Then you can click "Save" once more, and your additions will be saved to the OSM database!
 
 
-The iD editor is a fantastic way to easily edit OpenStreetMap, and you can find out more about using it in the [iD editor guide](/en/beginner/id-editor/).  You can also play the [walkthrough](http://www.openstreetmap.org/edit?editor=id#walkthrough=true) which is a great and interactive manner to discover the editor.
+The iD editor is a fantastic way to easily edit OpenStreetMap, and you can find out more about using it in the [iD editor guide](/en/beginner/id-editor/).  You can also play the [walkthrough](https://www.openstreetmap.org/edit?editor=id#walkthrough=true) which is a great and interactive manner to discover the editor.
 
 However, in the [JOSM section](/en/josm/) we will be looking at a standalone application that offers many more features.  Feel free to continue playing with iD. Once you have more experience contributing to OSM, you can choose which editor - iD or JOSM - you like using the best.
 

--- a/_posts/en/0450-10-05-saving_en.md
+++ b/_posts/en/0450-10-05-saving_en.md
@@ -34,7 +34,7 @@ Add a simple comment explaining what you have done at the end of the existing co
 
 For more information about changeset comments see <https://wiki.openstreetmap.org/wiki/Good_changeset_comments>  
 
-Your edits will appear on <http://www.openstreetmap.org> within a few seconds of uploading or saving them.  
+Your edits will appear on <https://www.openstreetmap.org> within a few seconds of uploading or saving them.  
 
 Although your changes are accepted by OpenStreetMap within a few seconds, some programmes, apps. and devices use a saved version of OpenStreetMap which may not be updated for some weeks or months.  
 

--- a/_posts/en/0450-12-29-hot-starting_en.md
+++ b/_posts/en/0450-12-29-hot-starting_en.md
@@ -14,7 +14,7 @@ Starting with a Tasking Manager - iD editor
 - TOC
 {:toc}
 
-This guide is written for the [HOT Tasking Manager](http://tasks.hotosm.org/), but the principles are the same for all versions.  
+This guide is written for the [HOT Tasking Manager](https://tasks.hotosm.org/), but the principles are the same for all versions.  
 
 The Essentials
 --------------
@@ -22,7 +22,7 @@ The Essentials
 ![TM Start][]
 
 
-1. Go to a Tasking Manager (TM) site, for example <http://tasks.hotosm.org/>. Using your <http://www.openstreetmap.org> login, authorise the Tasking Manager to access your OpenStreetMap account.  
+1. Go to a Tasking Manager (TM) site, for example <https://tasks.hotosm.org/>. Using your <https://www.openstreetmap.org> login, authorise the Tasking Manager to access your OpenStreetMap account.  
 2.  Start on a project designed for new mappers - these are often 'buildings only' projects.  
 3.  Read the **Description** and **Instructions** and make sure you understand what is needed before you start. 
 4.  The mapping is checked by 'validators' who often send messages giving valuable feedback on your contributions.  

--- a/_posts/en/0500-01-01-tm2-user_en.md
+++ b/_posts/en/0500-01-01-tm2-user_en.md
@@ -31,7 +31,7 @@ Section Index
 -  [Hints and Tips](/en/coordination/tasking-manager/#editing-hints-and-tips)
 
 
-The HOT Tasking Manager, <http://tasks.hotosm.org/>, is an intuitive tool that mappers can use to sort an area into a grid, and work together to map an area in an organized way. This allows mappers throughout the world to assist in mapping a defined region with a minimum risk of overlapping work areas, and also allows people both on the ground and working remotely (also sometimes referred to as "armchair mappers") to collaborate effectively, rapidly, and avoid accidental rework being required due to conflicts.  
+The HOT Tasking Manager, <https://tasks.hotosm.org/>, is an intuitive tool that mappers can use to sort an area into a grid, and work together to map an area in an organized way. This allows mappers throughout the world to assist in mapping a defined region with a minimum risk of overlapping work areas, and also allows people both on the ground and working remotely (also sometimes referred to as "armchair mappers") to collaborate effectively, rapidly, and avoid accidental rework being required due to conflicts.  
 
 
 ## Overview of the process
@@ -60,7 +60,7 @@ Once you have logged in, you may click on your username at the top. Here you can
 
 ## Getting started with the Tasking Manager
 
-You may view projects as a visitor, but to actively participate you must be logged into the Tasking Manager - use your OpenStreetMap account username & password. Open your Internet browser and go to <http://tasks.hotosm.org>. You will see a page like this:  
+You may view projects as a visitor, but to actively participate you must be logged into the Tasking Manager - use your OpenStreetMap account username & password. Open your Internet browser and go to <https://tasks.hotosm.org>. You will see a page like this:  
 
 ![Tasking Manager Login][]
 
@@ -80,7 +80,7 @@ The current list of projects may be sorted according to:
 
 You can further refine your list by clicking in the **Your Projects** box, to see just the projects in which you have participated, whether you have completed a square or not. Validators will also find projects they have contributed validated squares in, by using this checkbox. You may use a free text search to locate projects that contain particular text strings, such as **Ebola** (search is not case sensitive).  
 
-Projects are frequently referred to by their Project number, e.g., [**#711 - Ebola Outbreak, Kayes, Mali - Pre-emptive building mapping**](http://tasks.hotosm.org/project/711), and in this instance you could search on #711 to find this project.  
+Projects are frequently referred to by their Project number, e.g., [**#711 - Ebola Outbreak, Kayes, Mali - Pre-emptive building mapping**](https://tasks.hotosm.org/project/711), and in this instance you could search on #711 to find this project.  
 
 Click on a blue project title to see more information about that project.  
 
@@ -230,7 +230,7 @@ For example:
 
 This is particularly useful when validating or adding on another's previous work - you can provide feedback, thanks or more.  
 
-+ You may wish to provide a link to a site which may help the mapper, such as <http://learnosm.org/en/coordination/remote-tracing/#buildings-walls-compounds-barriers>  
++ You may wish to provide a link to a site which may help the mapper, such as <https://learnosm.org/en/coordination/remote-tracing/#buildings-walls-compounds-barriers>  
 + Be aware that many people from around the world will be participating, so prefer simple, clear language. If you come across comments in other languages, tools such as google translate are reasonable effective.
 
 
@@ -239,7 +239,7 @@ This is particularly useful when validating or adding on another's previous work
 If you need to send a message, such as an email or an IRC message, and you are querying something concerning a particular square within a project (perhaps you need help identifying something from the satellite imagery):  
 
 1. Click on the square concerned  
-2. Click on the address bar in your web browser, which should show something similar to 'http://tasks.hotosm.org/project/713#task/259'  
+2. Click on the address bar in your web browser, which should show something similar to 'https://tasks.hotosm.org/project/713#task/259'  
 3. Highlight with the mouse all of the text in the address bar, or use the shortcut keys **Ctrl+A** to select all the text, then use shortcut keys **Ctrl+C** to copy the text  
 4. In your email, IRC message, or other message,  
     - either, mouse right click & paste,  
@@ -261,7 +261,7 @@ From the tasking manager;
 - Type your message in the box at the bottom left of the screen (this is sometimes temporarily obscured by other text, but this will disappear as you select the box.  
 - To direct a message to a particular individual, include their username from the list on the right within your message. Type, then use the return key to submit your comment. The system is 'live' so wait for an answer - your username will often be used in the reply to show you the comment is directed to you. You will normally receive a reply within a few seconds, so please wait.  
 - An alternative simple system can be found at [kiwiIRC.com](https://kiwiirc.com/client/irc.oftc.net/hot)  
-- Further info on using IRC with OpenStreetMap may be found at [OSM Wiki IRC](http://wiki.openstreetmap.org/wiki/Irc)  
+- Further info on using IRC with OpenStreetMap may be found at [OSM Wiki IRC](https://wiki.openstreetmap.org/wiki/Irc)  
 - Alternatively use an IRC client of your choice (Server=irc.oftc.net, and channel=#hot)  
 
 

--- a/_posts/en/0500-01-02-tm2-admin_en.md
+++ b/_posts/en/0500-01-02-tm2-admin_en.md
@@ -13,12 +13,12 @@ navigation: skip
 
 The OpenStreetMap Tasking Manager is essential to conducting a mapathon, managing a HOT activation, or creating mapping tasks for student mappers. The Tasking Manager divides the work into manageable geographic chunks, which reduces editing conflicts, especially with large numbers of distributed mappers. The Tasking Manager also helps mapping accuracy and data quality by providing a consistent set of instructions for your mappers (e.g. 'map all roads and buildings'). In short, the Tasking Manager is how you set up and direct the workflow for open mapping activities. This module describes the basic administration of the OSM Tasking Manager for successful mapping events. 
 
- This guide is specifically written for those persons who need instructions on administration of the OSM Tasking Manager, including the creation and modification of mapping projects for open mapping events, i.e. 'mapathons'. This guide is applicable to all instances of the OSM Tasking Manager including the HOT Tasking Manager <http://tasks.hotosm.org/> and the TeachOSM Tasking Manager <http://tasks.teachosm.org/>. A list of other instances of the OSM Tasking Manager can be found at [the OpenStreetMap wiki](http://wiki.openstreetmap.org/wiki/OSM_Tasking_Manager#Operational_installations_of_the_Tasking_Manager)
+ This guide is specifically written for those persons who need instructions on administration of the OSM Tasking Manager, including the creation and modification of mapping projects for open mapping events, i.e. 'mapathons'. This guide is applicable to all instances of the OSM Tasking Manager including the HOT Tasking Manager <https://tasks.hotosm.org/> and the TeachOSM Tasking Manager <https://tasks.teachosm.org/>. A list of other instances of the OSM Tasking Manager can be found at [the OpenStreetMap wiki](https://wiki.openstreetmap.org/wiki/OSM_Tasking_Manager#Operational_installations_of_the_Tasking_Manager)
 
 The HOT or OSM Tasking Manager is frequently referred to as **TM2,** as a shorthand for Tasking Manager, version 2. 
 
 ## Logging in & Access Levels
-The first thing to understand is access level. All access to TM2 is authorized through <https://www.openstreetmap.org>. To access TM2 you will need an OpenStreetMap (OSM) account. Once you have this account visit <http://tasks.hotosm.org/> and click **Login to OpenStreetMap**, which will refer you back to the OSM page where you can authorize the Tasking Manager to have limited access to your OSM account. 
+The first thing to understand is access level. All access to TM2 is authorized through <https://www.openstreetmap.org>. To access TM2 you will need an OpenStreetMap (OSM) account. Once you have this account visit <https://tasks.hotosm.org/> and click **Login to OpenStreetMap**, which will refer you back to the OSM page where you can authorize the Tasking Manager to have limited access to your OSM account. 
 
 ### Access Levels within the OSM Tasking Manager
 The OSM Tasking Manager has three user access levels:
@@ -109,7 +109,7 @@ Here are some suggested bits of information which you might include in the proje
 
 - [general guidelines for various editors](https://wiki.openstreetmap.org/wiki/Using_Imagery)
 - [an animated gif on imagery alignment in iD](https://wiki.openstreetmap.org/w/images/1/1a/Id-adjust-imagery.gif)
-- [the josm imagery alignment chapter in learnOSM](http://learnosm.org/en/josm/correcting-imagery-offset)
+- [the josm imagery alignment chapter in learnOSM](https://learnosm.org/en/josm/correcting-imagery-offset)
 
 ## Create the project & add description
 After choosing a tile size, click “Create Project”. 
@@ -124,8 +124,8 @@ Please use plain language as your target audience may not consist of native Engl
 *#1396 - Missing Maps: Niger State (north), Nigeria (project 1: roads and residential areas )*
 2. The most important messages should appear on the instruction tab first to ensure they are read. This would include any special imagery to use instead of Bing. The first sentences could mention that it is not required to map every single house if the project is about roads and residential areas, for example. Or that it is required to map every house if the project is to be used for population density estimates. These are the messages that should also appear on the description tab.
 3. Other points of clarification: If the project is suitable for mappers with a certain level of experience only. For example, the project uses imports or existing data should be realigned to GPS traces or some other imagery (cf. the previous section). Phrase it so that new mappers will feel invited contributing to other projects but understand that advanced techniques are required in this instance.
-4. There are guidelines that cover common errors we see while validating. One example is Blake Girardot's compilation on [mapping in West Africa](http://wiki.openstreetmap.org/wiki/User:Bgirardot/West_African_HOT_Mapping_Tips). Use the link in the instructions and explain that adhering to these guidelines is required.
-5. The definitive resource on tagging is the [OpenStreetMap wiki](http://wiki.openstreetmap.org/wiki/Map_Features). For many HOT-related tasks the page on [tagging highways in Africa](http://wiki.openstreetmap.org/wiki/Highway_Tag_Africa) is the proper specialization and highly recommended reading for every mapper. If your project must adhere to different tagging standards then write a similar page in the wiki and link it in your instructions.
+4. There are guidelines that cover common errors we see while validating. One example is Blake Girardot's compilation on [mapping in West Africa](https://wiki.openstreetmap.org/wiki/User:Bgirardot/West_African_HOT_Mapping_Tips). Use the link in the instructions and explain that adhering to these guidelines is required.
+5. The definitive resource on tagging is the [OpenStreetMap wiki](https://wiki.openstreetmap.org/wiki/Map_Features). For many HOT-related tasks the page on [tagging highways in Africa](https://wiki.openstreetmap.org/wiki/Highway_Tag_Africa) is the proper specialization and highly recommended reading for every mapper. If your project must adhere to different tagging standards then write a similar page in the wiki and link it in your instructions.
 
 <!--Hidden Text - Google discussion group on TM - https://groups.google.com/a/hotosm.org/forum/?utm_medium=email&utm_source=footer#!msg/tm-project-managers/5OVNGMBsQv0/01Wxw95cBwAJ 
 
@@ -212,7 +212,7 @@ The “Misc” tab provides options to add a due date and a JOSM preset.  The du
 
 After entering the description, instructions, and any necessary information on the other tabs, click on “Save the Modifications”, which will take you back to the main project page.  
 
-Out of date wiki entry - for update when this guide complete  http://wiki.openstreetmap.org/wiki/Tasking_manager_admin
+Out of date wiki entry - for update when this guide complete  https://wiki.openstreetmap.org/wiki/Tasking_manager_admin
 - end of hidden text-->
   
 ### Proofread and Publish

--- a/_posts/en/0500-01-03-tm3-user_en.md
+++ b/_posts/en/0500-01-03-tm3-user_en.md
@@ -24,7 +24,7 @@ Section Index
 -  [Hints and Tips](/en/coordination/tasking-manager3/#editing-hints-and-tips)
 -  [Validation](/en/coordination/tasking-manager3/#validation)
 
-The [HOT OSM Tasking Manager](http://tasks.hotosm.org) is a tool that coordinates many people mapping a specific geographic area in OpenStreetMap.
+The [HOT OSM Tasking Manager](https://tasks.hotosm.org) is a tool that coordinates many people mapping a specific geographic area in OpenStreetMap.
 
 OpenStreetMap is a collabarative, crowd sourced, free map of the world. Anyone can contribute to OpenStreetMap to map any part of the world that interests them. The Tasking Manager is just a way to coordinate large groups of people contributing to OpenStreetMap but most contributions to OpenStreetMap are done by people not using the Tasking Manager.
 
@@ -45,7 +45,7 @@ Once you are done mapping that small area, you record in the Tasking Manager tha
 
 1. If you do not have an OpenStreetMap account then go to https://openstreetmap.org and create one. This will be the login details you use to log in to the Tasking Manager. <br/>
   ![TM Quick Start 1][]
-2. Visit [http://tasks.hotosm.org/](http://tasks.hotosm.org/) and log in via the upper right corner  
+2. Visit [https://tasks.hotosm.org/](https://tasks.hotosm.org/) and log in via the upper right corner  
   ![TM Quick Start 2][]
   > You must provide a valid email address in your profile (accessible through the first entry in the menu in the upper right corner) before you can start mapping.
 3. Click on "Contribute" and find a mapping project to work on  
@@ -285,7 +285,7 @@ For example:
 
 This is particularly useful when validating or adding on another's previous work - you can provide feedback, thanks or more.  
 
-+ You may wish to provide a link to a site which may help the mapper, such as <http://learnosm.org/en/coordination/remote-tracing/#buildings-walls-compounds-barriers>  
++ You may wish to provide a link to a site which may help the mapper, such as <https://learnosm.org/en/coordination/remote-tracing/#buildings-walls-compounds-barriers>  
 + Be aware that many people from around the world will be participating, so prefer simple, clear language. If you come across comments in other languages, tools such as Google Translate are reasonably effective.
 
 
@@ -294,7 +294,7 @@ This is particularly useful when validating or adding on another's previous work
 If you need to send a message, such as an email or an IRC message, and you are querying something concerning a particular task within a project (perhaps you need help identifying something from the satellite imagery):  
 
 1. Click on the task square concerned  
-2. Click on the address bar in your web browser, which should show something similar to 'http://tasks.hotosm.org/project/713?task=259'  
+2. Click on the address bar in your web browser, which should show something similar to 'https://tasks.hotosm.org/project/713?task=259'  
 3. Copy this link into the message. 
 
 

--- a/_posts/en/0500-01-04-tm3-admin_en.md
+++ b/_posts/en/0500-01-04-tm3-admin_en.md
@@ -29,13 +29,13 @@ Section Index
 
 The OpenStreetMap Tasking Manager is essential to conducting a mapathon, managing a HOT activation, or creating mapping tasks for student mappers. The Tasking Manager divides the work into manageable geographic chunks, which reduces editing conflicts, especially with large numbers of distributed mappers. The Tasking Manager also helps mapping accuracy and data quality by providing a consistent set of instructions for your mappers (e.g. 'map all roads and buildings'). In short, the Tasking Manager is how you set up and direct the workflow for open mapping activities. This module describes the basic administration of the OSM Tasking Manager for successful mapping events. 
 
- This guide is specifically written for those persons who need instructions on administration of the OSM Tasking Manager, including the creation and modification of mapping projects for open mapping events, i.e. 'mapathons'. This guide is specifically applicable to instances of the OSM Tasking Manager version 3 including the [HOT Tasking Manager](http://tasks.hotosm.org) and the [TeachOSM Tasking Manager](http://tasks.teachosm.org).
+ This guide is specifically written for those persons who need instructions on administration of the OSM Tasking Manager, including the creation and modification of mapping projects for open mapping events, i.e. 'mapathons'. This guide is specifically applicable to instances of the OSM Tasking Manager version 3 including the [HOT Tasking Manager](https://tasks.hotosm.org) and the [TeachOSM Tasking Manager](https://tasks.teachosm.org).
 
 The HOT or OSM Tasking Manager version 3 is frequently referred to as **TM3,** as a shorthand for Tasking Manager, version 3.
 
 ## Logging in & Access Levels
 
-The first thing to understand is access level. All access to TMd is authorized through the [OpenStreetMap website](https://www.openstreetmap.org). To access TM3 you will need an OpenStreetMap (OSM) account. Once you have this account visit [the Tasking Manager](http://tasks.hotosm.org) and click **Login to OpenStreetMap**, which will refer you back to the OSM page where you can authorize the Tasking Manager to have limited access to your OSM account. 
+The first thing to understand is access level. All access to TMd is authorized through the [OpenStreetMap website](https://www.openstreetmap.org). To access TM3 you will need an OpenStreetMap (OSM) account. Once you have this account visit [the Tasking Manager](https://tasks.hotosm.org) and click **Login to OpenStreetMap**, which will refer you back to the OSM page where you can authorize the Tasking Manager to have limited access to your OSM account. 
 
 ### Access Levels within the OSM Tasking Manager
 
@@ -52,7 +52,7 @@ You will need Project Manager Access level to create new projects using TM3.
 
 Click your username in the upper right corner, then **Create a New Project.** You then may choose between drawing your area of interest (AoI) on the map, or importing an area of interest from a geojson file;  
 
-> Importing a file with a defined area is always preferable to hand drawing a Tasking Manager project. Tools like JOSM, QGIS, etc can be used to create files for importing into the Tasking Manager. The suggested workflow is to create a .osm file of the AoI using JOSM and then use http://geojson.io/ to generate a GeoJSON.
+> Importing a file with a defined area is always preferable to hand drawing a Tasking Manager project. Tools like JOSM, QGIS, etc can be used to create files for importing into the Tasking Manager. The suggested workflow is to create a .osm file of the AoI using JOSM and then use https://geojson.io/ to generate a GeoJSON.
 
 ### Draw an area of interest to be mapped
 
@@ -227,8 +227,8 @@ Please use plain language as your target audience may not consist of native Engl
 *#1396 - Missing Maps: Niger State (north), Nigeria (project 1: roads and residential areas )*
 2. The most important messages should appear on the instruction tab first to ensure they are read. This would include any special imagery to use instead of Bing. The first sentences could mention that it is not required to map every single house if the project is about roads and residential areas, for example. Or that it is required to map every house if the project is to be used for population density estimates. These are the messages that should also appear on the description tab.
 3. Other points of clarification: If the project is suitable for mappers with a certain level of experience only. For example, the project uses imports or existing data should be realigned to GPS traces or some other imagery (cf. the previous section). Phrase it so that new mappers will feel invited contributing to other projects but understand that advanced techniques are required in this instance.
-4. There are guidelines that cover common errors we see while validating. One example is Blake Girardot's compilation on [mapping in West Africa](http://wiki.openstreetmap.org/wiki/User:Bgirardot/West_African_HOT_Mapping_Tips). Use the link in the instructions and explain that adhering to these guidelines is required.
-5. The definitive resource on tagging is the [OpenStreetMap wiki](http://wiki.openstreetmap.org/wiki/Map_Features). For many HOT-related tasks the page on [tagging highways in Africa](http://wiki.openstreetmap.org/wiki/Highway_Tag_Africa) is the proper specialization and highly recommended reading for every mapper. If your project must adhere to different tagging standards then write a similar page in the wiki and link it in your instructions.
+4. There are guidelines that cover common errors we see while validating. One example is Blake Girardot's compilation on [mapping in West Africa](https://wiki.openstreetmap.org/wiki/User:Bgirardot/West_African_HOT_Mapping_Tips). Use the link in the instructions and explain that adhering to these guidelines is required.
+5. The definitive resource on tagging is the [OpenStreetMap wiki](https://wiki.openstreetmap.org/wiki/Map_Features). For many HOT-related tasks the page on [tagging highways in Africa](https://wiki.openstreetmap.org/wiki/Highway_Tag_Africa) is the proper specialization and highly recommended reading for every mapper. If your project must adhere to different tagging standards then write a similar page in the wiki and link it in your instructions.
 
 
 ### Considerations concerning Imagery
@@ -260,7 +260,7 @@ Here are some suggested bits of information which you might include in the proje
 
 - [general guidelines for various editors](https://wiki.openstreetmap.org/wiki/Using_Imagery)
 - [an animated gif on imagery alignment in iD](https://wiki.openstreetmap.org/w/images/1/1a/Id-adjust-imagery.gif)
-- [the josm imagery alignment chapter in learnOSM](http://learnosm.org/en/josm/correcting-imagery-offset)
+- [the josm imagery alignment chapter in learnOSM](https://learnosm.org/en/josm/correcting-imagery-offset)
 
 
 ### Proofread and Publish

--- a/_posts/en/0500-10-10-review_en.md
+++ b/_posts/en/0500-10-10-review_en.md
@@ -14,7 +14,7 @@ Reviewing OSM Data
 - TOC
 {:toc}
 
-**This section covers processes for checking data quality, particularly in the context of a directed OSM mapping project, such as those undertaken by the [Humanitarian OpenStreetMap Team](http://hotosm.org) in various countries and [Open Cities](http://opencitiesproject.com) projects in Bangladesh, Sri Lanka, and Nepal. The methods demonstrated may be useful in other contexts as well, when data quality review is a regular task.**
+**This section covers processes for checking data quality, particularly in the context of a directed OSM mapping project, such as those undertaken by the [Humanitarian OpenStreetMap Team](https://hotosm.org) in various countries and [Open Cities](https://opencitiesproject.com) projects in Bangladesh, Sri Lanka, and Nepal. The methods demonstrated may be useful in other contexts as well, when data quality review is a regular task.**
 
 When we are trying to map a complete set of features and attributes in a specified area, we need ways to check for mistakes and ways to assess the accuracy of the work.  In this tutorial we will work through several methods of checking data, explaining the steps of the method and the reason behind each.  A well-managed mapping project will include each of these three processes, both for evaluating and correcting data and for reporting.
 
@@ -54,7 +54,7 @@ Here we will look at some methods for checking data simply using JOSM.  Some of 
 
 Let’s examine how we can find answers to these questions in JOSM.  We’ll assume that we are examining the work of others, but the same processes will work fine (and should be easier) when analyzing your own work.
 
-We will be using an example data file from the Open Cities mapping project in Dhaka. To follow along, download the following file: [dhaka_validation_example.osm](http://learnosm.org/files/dhaka_validation_example.osm)
+We will be using an example data file from the Open Cities mapping project in Dhaka. To follow along, download the following file: [dhaka_validation_example.osm](https://learnosm.org/files/dhaka_validation_example.osm)
 
 **DO NOT try to save your changes on OpenStreetMap.  These exercises are for demonstration purposes only.**
 
@@ -180,7 +180,7 @@ SQL Queries
 -----------
 Probably the best analysis tool is going to be running SQL Queries in a GIS system, such as Quantum GIS.  This is similar to searching for data in JOSM, but it offers more powerful analysis, though it can take a little more time to set up.  Using JOSM is a quick, regular way to check for basic errors, whereas querying in QGIS is better suited for finding missing data or incorrect attributes.
 
-We’ll assume here that you are somewhat familiar with GIS, and focus on building queries which can help you to review OpenStreetMap data.  For the exercises below we’ll again be using data from the Open Cities Dhaka project, which you can download at [dhaka_sql.zip](http://learnosm.org/files/dhaka_sql.zip).  The OpenStreetMap data was exported using the HOT Export Tool ([export.hotosm.org](http://export.hotosm.org)) and the target area boundary was defined at the start of the project.
+We’ll assume here that you are somewhat familiar with GIS, and focus on building queries which can help you to review OpenStreetMap data.  For the exercises below we’ll again be using data from the Open Cities Dhaka project, which you can download at [dhaka_sql.zip](https://learnosm.org/files/dhaka_sql.zip).  The OpenStreetMap data was exported using the HOT Export Tool ([export.hotosm.org](https://export.hotosm.org)) and the target area boundary was defined at the start of the project.
 
 ### Prepare the Data
 Unzip the files and load the two shapefiles into QGIS.  We’ll begin by clipping only the buildings within the project area, to make our queries more simple later on.

--- a/_posts/en/0500-10-12-mapathon_en.md
+++ b/_posts/en/0500-10-12-mapathon_en.md
@@ -66,12 +66,12 @@ Now that you have enough information from your first steps to decide the numbers
 2.  Book the venue. Make sure the location of the venue is on Openstreetmap.  
 3.  Distribute invites to Mappers through local and online media to aim for good attendance. [Eventbrite](https://www.eventbrite.co.uk/) is a good way of booking places at the event.  
 4.  Will you be providing snacks/refreshments at the event? (Pizza has proved to be a popular choice but choose the popular foods for your part of the world).  
-5.  Set up a project for the event. Remember that your first Mapathon in your area will possibly comprise a large proportion of beginners. Suggest that you have two easy projects for beginners and two more challenging tasks for more experienced mappers. Contact the [Missing Maps Project](http://missingmaps.org) if you need help with setting up projects and also for Mapathon materials for the tables and direction signs for the corridors. The [Tasking Manager](http://tasks.hotosm.org) is a good source of useful projects.  
+5.  Set up a project for the event. Remember that your first Mapathon in your area will possibly comprise a large proportion of beginners. Suggest that you have two easy projects for beginners and two more challenging tasks for more experienced mappers. Contact the [Missing Maps Project](https://missingmaps.org) if you need help with setting up projects and also for Mapathon materials for the tables and direction signs for the corridors. The [Tasking Manager](https://tasks.hotosm.org) is a good source of useful projects.  
 6.  Suggested helpers that you may need for the event  
   *    An experienced mapper to talk them through the mapping process.  
   *    An IT person from the venue to trouble shoot any connectivity problems.  
   *    A guest speaker to talk about their experiences with Openstreetmap  
-  *    Ideally one experienced mapper per table to check that they know what to do and to answer any questions. Contact the [Missing Maps Project](http://missingmaps.org) to assist in finding helpers and also check for [experienced mappers in your area](http://resultmaps.neis-one.org/oooc)
+  *    Ideally one experienced mapper per table to check that they know what to do and to answer any questions. Contact the [Missing Maps Project](https://missingmaps.org) to assist in finding helpers and also check for [experienced mappers in your area](https://resultmaps.neis-one.org/oooc)
   *    A deputy to help with the arrangements and stand in for you as a back up.   
 7.  Add your event to the Mapathon calendar.
 8.   Have someone available from the local media to take photos and report the event.

--- a/_posts/en/0500-10-15-remote-tracing_en.md
+++ b/_posts/en/0500-10-15-remote-tracing_en.md
@@ -39,7 +39,7 @@ Any type of roads from motorways to tracks and paths are labelled 'highway' in O
 1.  When tracing highways, ensure you are zoomed in sufficiently. As a starting guide set the scale to about 20 metres, and trace the highway so that your tracing has sufficient points in it to keep it on, or very close to, the road you can see in your satellite imagery. In the screenshot above you can see I have traced the road that had been passed over to me, down, through the trees, and down to another building where it appears to stop. Where the trees are close to the road, and the imagery is obtained by an overhead camera, it appears as if the road narrows as it goes through the trees - however, it is just the effect of the trees obscuring the view, and the road is the same width throughout.  
 2.  I've also traced another section of road, making sure that it is connected at each end - iD shows this with a slightly larger and darker coloured dot at the junction. It is important that the roads join and 'share a common node' so that routing software will provide the correct guidance.  
 3.  The road is tagged as 'highway=residential', and I've also added 'surface=unpaved'.  
-4.  For a full description of tagging within Africa, refer to the wiki page [Highway Tag Africa](http://wiki.openstreetmap.org/wiki/Highway_Tag_Africa).  
+4.  For a full description of tagging within Africa, refer to the wiki page [Highway Tag Africa](https://wiki.openstreetmap.org/wiki/Highway_Tag_Africa).  
 
 > There is a high risk of suffering from conflicts which will prevent you saving your work when working on any highway which extends into other squares where mappers will also be editing it. It is advisable to save all your changes before editing the highway, and then save your changes at very frequent intervals, such as after adding each 6 nodes.
 
@@ -75,7 +75,7 @@ surface=unpaved
 
 Residential boundaries are used for many purposes in OpenStreetMap.  
 
-+  The simplest use is to be able to see residential areas at higher zoom levels when viewing [OpenStreetMap.org](http://www.openstreetmap.org), where they are coloured pale grey in the standard view.  
++  The simplest use is to be able to see residential areas at higher zoom levels when viewing [OpenStreetMap.org](https://www.openstreetmap.org), where they are coloured pale grey in the standard view.  
 +  Where there is not time to map in detail from the outset, the project within the Task Manager will frequently require something similar to this:  
 
 >    Map essential infrastructures such as schools, place of worship and markets.  
@@ -179,10 +179,10 @@ More to follow - see the below links for more guidance.
 
 # Further Reading
 
--  [West African HOT Mapping Tips by user Bgirardot](http://wiki.openstreetmap.org/wiki/User:Bgirardot/Typical_Road_and_Residential_Task)  
--  [OSM wiki entry concerning validating](http://wiki.openstreetmap.org/wiki/OSM_Tasking_Manager/Validating_data)  
--  [Highway Tag Africa - the preferred reference for highway tagging in Africa](http://wiki.openstreetmap.org/wiki/Highway_Tag_Africa)  
--  [Short Tutorial in French for remote mapping](http://blog.cartong.org/2014/07/24/tuto-digitaliser-sous-openstreetmap-avec-le-tasking-manager-et-josm-premiers-pas/)
+-  [West African HOT Mapping Tips by user Bgirardot](https://wiki.openstreetmap.org/wiki/User:Bgirardot/Typical_Road_and_Residential_Task)  
+-  [OSM wiki entry concerning validating](https://wiki.openstreetmap.org/wiki/OSM_Tasking_Manager/Validating_data)  
+-  [Highway Tag Africa - the preferred reference for highway tagging in Africa](https://wiki.openstreetmap.org/wiki/Highway_Tag_Africa)  
+-  [Short Tutorial in French for remote mapping](https://blog.cartong.org/2014/07/24/tuto-digitaliser-sous-openstreetmap-avec-le-tasking-manager-et-josm-premiers-pas/)
 
 [iD 3]: /images/coordination/iD_3.png
 [JOSM 4]: /images/coordination/JOSM_4.png

--- a/_posts/en/0500-10-20-remote_en.md
+++ b/_posts/en/0500-10-20-remote_en.md
@@ -29,7 +29,7 @@ Remote mapping is also referred to as 'Armchair mapping', and this is probably t
 Overview of Remote, Armchair or Mapathon mapping
 ================================================
 
-1. An administrator selects an area requiring updating in OpenStreetMap. The administrator ensures there is suitable satellite imagery available for remote mappers to trace, and creates a project covering the area. The level of detail required and the urgency are specified within the project together with any other information the remote mapper will require. When satisfied, the administrator publishes the project within the Tasking Manager [tasks.hotosm.org](http://tasks.hotosm.org), although they may also make changes later if required.
+1. An administrator selects an area requiring updating in OpenStreetMap. The administrator ensures there is suitable satellite imagery available for remote mappers to trace, and creates a project covering the area. The level of detail required and the urgency are specified within the project together with any other information the remote mapper will require. When satisfied, the administrator publishes the project within the Tasking Manager [tasks.hotosm.org](https://tasks.hotosm.org), although they may also make changes later if required.
 
 2. A remote mapper selects a task square, completes the mapping, and marks the square as complete.
 
@@ -46,7 +46,7 @@ Take a few minutes to look at each of these - just a quick read so you know roug
 -  [OpenStreetMap.org section of LearnOSM](/en/beginner/start-osm/). This covers just the basics about OpenStreetMap, and reading this will help you a lot - it's not a big chapter so it won't take you long to read it all. While you are reading it, use the information to help you create an OpenStreetMap account, and to confirm it with the email link. Make sure you have a record of your username and password.
 -  [Tasking Manager Section of LearnOSM](/en/coordination/tm-user/). You will need to know how to log into the Tasking Manager, find a particular project, select a square, and what to do with it. You need to read the whole chapter!  
 
-You may also like to view the short video's provided by [MapGive](http://mapgive.state.gov/learn-to-map/) - please be aware the OSM Tasking Manager has been upgraded since the video was made - the principles are the same but the colours have altered.
+You may also like to view the short video's provided by [MapGive](https://mapgive.state.gov/learn-to-map/) - please be aware the OSM Tasking Manager has been upgraded since the video was made - the principles are the same but the colours have altered.
 
 
 Editing Software
@@ -65,7 +65,7 @@ Don't give up on us now - we've thrown a lot of information at you, but it shoul
 -  You know what the OSM Tasking Manager does, and have an idea about how you will use it, and  
 -  You've decided which editing software you are going to start with, and you have an idea how it is used.
 
-We're now going to select a square from a project and start to map it. If you are at a mapathon, or assisting remotely, the organisers will have provided instructions as to which project you should be working on. If you are working alone, look through the list of projects in the Tasking Manager [tasks.hotosm.org](http://tasks.hotosm.org) and try to find a project which is suitable for beginners, and choose a project. You've probably already had a quick read of the information on the Instructions Tab of the project, but you need to thoroughly understand what is needed - do you need to read it again?
+We're now going to select a square from a project and start to map it. If you are at a mapathon, or assisting remotely, the organisers will have provided instructions as to which project you should be working on. If you are working alone, look through the list of projects in the Tasking Manager [tasks.hotosm.org](https://tasks.hotosm.org) and try to find a project which is suitable for beginners, and choose a project. You've probably already had a quick read of the information on the Instructions Tab of the project, but you need to thoroughly understand what is needed - do you need to read it again?
 
 Having selected the project you are going to work on, now select a square and then using the drop down list, load it into your chosen editor. 
 
@@ -131,10 +131,10 @@ The next section of this guide indicates how features should be mapped & tagged.
 
 # Further Reading
 
--  [West African HOT Mapping Tips by user Bgirardot](http://wiki.openstreetmap.org/wiki/User:Bgirardot/Typical_Road_and_Residential_Task)  
--  [OSM wiki entry concerning validating](http://wiki.openstreetmap.org/wiki/OSM_Tasking_Manager/Validating_data)  
--  [Highway Tag Africa - the preferred reference for highway tagging in Africa](http://wiki.openstreetmap.org/wiki/Highway_Tag_Africa)  
--  [Short Tutorial in French for remote mapping](http://blog.cartong.org/2014/07/24/tuto-digitaliser-sous-openstreetmap-avec-le-tasking-manager-et-josm-premiers-pas/)
+-  [West African HOT Mapping Tips by user Bgirardot](https://wiki.openstreetmap.org/wiki/User:Bgirardot/Typical_Road_and_Residential_Task)  
+-  [OSM wiki entry concerning validating](https://wiki.openstreetmap.org/wiki/OSM_Tasking_Manager/Validating_data)  
+-  [Highway Tag Africa - the preferred reference for highway tagging in Africa](https://wiki.openstreetmap.org/wiki/Highway_Tag_Africa)  
+-  [Short Tutorial in French for remote mapping](https://blog.cartong.org/2014/07/24/tuto-digitaliser-sous-openstreetmap-avec-le-tasking-manager-et-josm-premiers-pas/)
 
 
 [JOSM 1]: /images/coordination/JOSM_1.png

--- a/_posts/en/0500-10-24-tm-admin_en.md
+++ b/_posts/en/0500-10-24-tm-admin_en.md
@@ -48,7 +48,7 @@ This guide describes the basic administration of the Tasking Manager. It covers 
 
 ## Login and access
 
-In order to login to the Tasking Manager an OpenStreetMap (OSM) account is needed. You can visit the [HOT Tasking Manager](http://tasks.hotosm.org), or any other community instance of your preference. There click `Sign up` and it redirects you to the [OpenStreetMap website](https://www.openstreetmap.org) to create your account. Or click `Log in` if you have already one, and in the pop-up you can give the Tasking Manager limited access to your OSM account.
+In order to login to the Tasking Manager an OpenStreetMap (OSM) account is needed. You can visit the [HOT Tasking Manager](https://tasks.hotosm.org), or any other community instance of your preference. There click `Sign up` and it redirects you to the [OpenStreetMap website](https://www.openstreetmap.org) to create your account. Or click `Log in` if you have already one, and in the pop-up you can give the Tasking Manager limited access to your OSM account.
 
 ## Permissions
 
@@ -229,9 +229,9 @@ Add descriptive instructions for mappers and validators to follow while working 
 1. Write the most important information at the top to ensure it is prominent. This could includes a description of the imagery and a warning of an imagery offset issue with guidance. Or it might instruct mappers to ignore paths and tracks in a highway mapping project and focus on more prominent highways.
 2. Add context/location specific instructions. These vary significantly but will help mappers interpret satellite imagery. E.g. 'Expect to see many circular brown thatched huts in this South Sudan project' or 'Settlements in Guatemala are often densely built, zoom extremely far in when mapping each building to ensure they do not connect or overlap'. Drag and drop aerial imagery screenshots into the instructions here to enhance this section.
 3. Definitely include a detailed description of **how to map each feature** that you wish to be mapped. Look at existing (but recent) projects on Tasking Manager to see if you can borrow some existing instructional text (beware that some projects will not have good instructions!).
-4. The definitive resource on tagging is the [OpenStreetMap wiki](http://wiki.openstreetmap.org/wiki/Map_Features). For many HOT-related projects the page on [tagging highways in Africa](http://wiki.openstreetmap.org/wiki/Highway_Tag_Africa) is the proper specialization and may be worth linking to in your project's instructions. If your project must adhere to different tagging standards then write a similar page in the Wiki and link it in your instructions.
+4. The definitive resource on tagging is the [OpenStreetMap wiki](https://wiki.openstreetmap.org/wiki/Map_Features). For many HOT-related projects the page on [tagging highways in Africa](https://wiki.openstreetmap.org/wiki/Highway_Tag_Africa) is the proper specialization and may be worth linking to in your project's instructions. If your project must adhere to different tagging standards then write a similar page in the Wiki and link it in your instructions.
 5. Other points of clarification: If the project is suitable for mappers with a certain level of experience only. For example, the project uses imports or existing data should be realigned to GPS traces or some other imagery. Phrase it so that new mappers will feel invited contributing to other projects but understand that advanced techniques are required in this instance.
-6. There are guidelines that cover common errors we see while validating. One example is Blake Girardot's compilation on [mapping in West Africa](http://wiki.openstreetmap.org/wiki/User:Bgirardot/West_African_HOT_Mapping_Tips). Use the link in the instructions and explain that adhering to these guidelines is required.
+6. There are guidelines that cover common errors we see while validating. One example is Blake Girardot's compilation on [mapping in West Africa](https://wiki.openstreetmap.org/wiki/User:Bgirardot/West_African_HOT_Mapping_Tips). Use the link in the instructions and explain that adhering to these guidelines is required.
 
 #### Per Task Instructions 
 
@@ -462,7 +462,7 @@ Please feel free to check these additional resources on imagery alignment:
 
 - [General guidelines for various editors](https://wiki.openstreetmap.org/wiki/Using_Imagery)
 - [Animated gif on imagery alignment in iD](https://wiki.openstreetmap.org/w/images/1/1a/Id-adjust-imagery.gif)
-- [JOSM imagery alignment chapter in learnOSM](http://learnosm.org/en/josm/correcting-imagery-offset)
+- [JOSM imagery alignment chapter in learnOSM](https://learnosm.org/en/josm/correcting-imagery-offset)
 
 
 [TM Tile Sizes]: /images/coordination/tm4_tile_sizes.png

--- a/_posts/en/0500-10-25-tm-user_en.md
+++ b/_posts/en/0500-10-25-tm-user_en.md
@@ -18,7 +18,7 @@ The Tasking Manager is the most popular tool to team up and coordinate mapping o
 
 > OpenStreetMap.org is a collaborative, crowd sourced, free map of the world. Anyone can contribute to OpenStreetMap to map any part of the world that interests them.
 
-You can use the widely used [HOT Tasking Manager](http://tasks.hotosm.org) to get started mapping immediately for humanitarian organizations and their work in the field.
+You can use the widely used [HOT Tasking Manager](https://tasks.hotosm.org) to get started mapping immediately for humanitarian organizations and their work in the field.
 
 The Tasking Manager is one software in the whole OpenStreetMap ecosystem. When you are contributing to OpenStreetMap using the Tasking Manager, you are actually using multiple software tools:
 
@@ -35,14 +35,14 @@ Experienced mappers are going to check each of the tasks and make sure the quali
 
 ## Quick Start Guide
 
-1. Do you have an OpenStreetMap account already? You can skip ahead to step 4. Otherwise click on the `Sign up` button in the upper right corner of the [Tasking Manager](http://tasks.hotosm.org/) homepage.
+1. Do you have an OpenStreetMap account already? You can skip ahead to step 4. Otherwise click on the `Sign up` button in the upper right corner of the [Tasking Manager](https://tasks.hotosm.org/) homepage.
   ![TM4-user-guide-1][]
 1. You will be asked to provide a name and an email address.
   ![TM4-user-guide-2a][]
   ![TM4-user-guide-2b][]
 1. A new tab will open allowing you to register on OpenStreetMap.org. Provide your account information and press the `Sign up` button at the bottom of the form.
   ![TM4-user-guide-3][]
-1. Close the tab and go back to the [Tasking Manager](http://tasks.hotosm.org/). Click the button to `Log in`.
+1. Close the tab and go back to the [Tasking Manager](https://tasks.hotosm.org/). Click the button to `Log in`.
   ![TM4-user-guide-4a][]
   ![TM4-user-guide-4b][]
 1. Select `Explore projects` in the main navigation to find a project to map on.
@@ -326,7 +326,7 @@ For example:
 
 This is particularly useful when validating or adding on another's previous work - you can provide feedback, thanks or more.  
 
-+ You may wish to provide a link to a site which may help the mapper, such as <http://learnosm.org/en/coordination/remote-tracing/#buildings-walls-compounds-barriers>  
++ You may wish to provide a link to a site which may help the mapper, such as <https://learnosm.org/en/coordination/remote-tracing/#buildings-walls-compounds-barriers>  
 + Be aware that many people from around the world will be participating, so prefer simple, clear language. If you come across comments in other languages, tools such as Google Translate are reasonably effective.
 
 <!-- unfortunately no longer available in TM4
@@ -335,7 +335,7 @@ This is particularly useful when validating or adding on another's previous work
 If you need to send a message, such as an email or an IRC message, and you are querying something concerning a particular task within a project (perhaps you need help identifying something from the satellite imagery):  
 
 1. Click on the task square concerned  
-2. Click on the address bar in your web browser, which should show something similar to 'http://tasks.hotosm.org/project/713?task=259'  
+2. Click on the address bar in your web browser, which should show something similar to 'https://tasks.hotosm.org/project/713?task=259'  
 3. Copy this link into the message. 
 -->
 

--- a/_posts/en/0500-12-06-remote-mapping_en.md
+++ b/_posts/en/0500-12-06-remote-mapping_en.md
@@ -20,18 +20,18 @@ The majority of HOT’s response activities occur remotely. After a disaster str
 
 Considering the scale of the crisis, HOT allocates the necessary resources and the response is coordinated by a specific team or member who makes sure everyone knows when new resources are available as well as where to focus efforts. HOT fosters the engagement of the OSM community and, if existing, local actors to use tools like the Tasking Manager to coordinate response efforts. Examples include the remote activities done in Ivory Coast, Senegal, Philippines, and the Democratic Republic of the Congo.  
 
-[Syria Activation Example](http://hot.openstreetmap.org/updates/2013-01-28_syria_activation)  
+[Syria Activation Example](https://hot.openstreetmap.org/updates/2013-01-28_syria_activation)  
 
 ### The HOT Tasking Manager 
 
-The [HOT Tasking Manager](http://tasks.hotosm.org/) is a open source tool designed to divide up a mapping job into smaller tasks that can be completed rapidly. It shows which areas need to be mapped and which areas need the mapping validated by others. It includes mapping tasks for [Activations](http://wiki.openstreetmap.org/wiki/HOT_activation), and longer standing [Humanitarian Projects](http://hot.openstreetmap.org/projects).  
+The [HOT Tasking Manager](https://tasks.hotosm.org/) is a open source tool designed to divide up a mapping job into smaller tasks that can be completed rapidly. It shows which areas need to be mapped and which areas need the mapping validated by others. It includes mapping tasks for [Activations](https://wiki.openstreetmap.org/wiki/HOT_activation), and longer standing [Humanitarian Projects](https://hot.openstreetmap.org/projects).  
 
 In order to use the HOT Tasking Manager you need to sign up with OpenStreetMap (OSM) with a username and password. For more instructions read the [Tasking Manager Tutorial](/en/coordination/tm-user/).  
 
 
 ### Editing Tools 
 
-[iD](http://learnosm.org/en/beginner/id-editor/) - the web-based editor created by [Mapbox](https://www.mapbox.com) with a very user-friendly interface. Generally considered the best editing tool to start with. You can launch this [interactive iD editor tutorial](http://ideditor.com/) to get acquainted with how to use it.  
+[iD](https://learnosm.org/en/beginner/id-editor/) - the web-based editor created by [Mapbox](https://www.mapbox.com) with a very user-friendly interface. Generally considered the best editing tool to start with. You can launch this [interactive iD editor tutorial](https://ideditor.com/) to get acquainted with how to use it.  
 
 ![iDeditor](https://blog.openstreetmap.org/wp-content/uploads/2013/08/id-editor-sotm-us-2013-venue-screenshot.png)  
 
@@ -56,14 +56,14 @@ This guide has been summarized and collected from a variety of existing tutorial
 
 #### Tutorials
 
-[LearnOSM's Remote Mapping Guide](http://learnosm.org/en/coordination/remote/)- one of the most comprehensive guides  
+[LearnOSM's Remote Mapping Guide](https://learnosm.org/en/coordination/remote/)- one of the most comprehensive guides  
 
-[MapGive's Learn To Map tutorial](http://mapgive.state.gov/learn-to-map/)- includes videos that you can pause to follow along  
+[MapGive's Learn To Map tutorial](https://mapgive.state.gov/learn-to-map/)- includes videos that you can pause to follow along  
 
 [HotQuickStartGuide](https://gist.github.com/meetar/b9929dfec129d1d7f5f2) - written by Peter Richardson (@meetar) an experienced HOT Remote Response Volunteer. Attention: the given information is outdated, but still useful. 
 
 #### About HOT 
 
-[HOT Wiki Page](http://wiki.openstreetmap.org/wiki/Humanitarian_OSM_Team) -  learn more about how HOT operates and some of their latest news  
+[HOT Wiki Page](https://wiki.openstreetmap.org/wiki/Humanitarian_OSM_Team) -  learn more about how HOT operates and some of their latest news  
 
 [HOT Activities](https://www.hotosm.org/what-we-do) - describes HOT activities in more detail from their website  

--- a/_posts/en/0600-12-08-osmosis_en.md
+++ b/_posts/en/0600-12-08-osmosis_en.md
@@ -12,7 +12,7 @@ Manipulating Data with Osmosis
 
 **Osmosis** is a powerful command-line tool for manipulating and processing raw **.osm** data. It is often used for processing large data files, for splitting OSM files into smaller pieces, and for applying a changeset to update an existing file.  
 
-There are a great many functions available with Osmosis, and you can read about each in detail on the [Wiki](http://wiki.openstreetmap.org/wiki/Osmosis/Detailed_Usage_0.41). However many of the functions are quite complex and difficult to understand, particularly if you are just getting started with command-line programs and OpenStreetMap. This chapter will serve to introduce Osmosis, install it on Windows, and get started with a basic Osmosis command.  
+There are a great many functions available with Osmosis, and you can read about each in detail on the [Wiki](https://wiki.openstreetmap.org/wiki/Osmosis/Detailed_Usage_0.41). However many of the functions are quite complex and difficult to understand, particularly if you are just getting started with command-line programs and OpenStreetMap. This chapter will serve to introduce Osmosis, install it on Windows, and get started with a basic Osmosis command.  
 
 Install Osmosis
 ----------------
@@ -116,9 +116,9 @@ Lastly, we supply the name and format of the output file. We use the flag **-wx*
 Moving Forward
 ---------------
 
-The number of processing tasks that can be done with Osmosis is enormous, and to learn more it is best to refer to the [Osmosis Detailed Usage](http://wiki.openstreetmap.org/wiki/Osmosis/Detailed_Usage_0.43) page on the Wiki.  
+The number of processing tasks that can be done with Osmosis is enormous, and to learn more it is best to refer to the [Osmosis Detailed Usage](https://wiki.openstreetmap.org/wiki/Osmosis/Detailed_Usage_0.43) page on the Wiki.  
 
-One useful task is being able to divide a big raw OSM file into separate parts, either by supplying rectangles or by creating bounding polygon files. You can get a basic grounding in this process at the [Osmosis Examples page](http://wiki.openstreetmap.org/wiki/Osmosis/Examples).  
+One useful task is being able to divide a big raw OSM file into separate parts, either by supplying rectangles or by creating bounding polygon files. You can get a basic grounding in this process at the [Osmosis Examples page](https://wiki.openstreetmap.org/wiki/Osmosis/Examples).  
 
 [unzip it]: /images/osm-data/unzip-it.png
 [system path]: /images/osm-data/system-path.png

--- a/_posts/en/0600-12-09-osm2pgsql_en.md
+++ b/_posts/en/0600-12-09-osm2pgsql_en.md
@@ -17,7 +17,7 @@ We will go through the steps to set up osm2pgsql on Windows, though the steps sh
 Get osm2pgsql
 -------------
 
-To download the windows version of osm2pgsql, navigate your web browser to <http://wiki.openstreetmap.org/wiki/Osm2pgsql#Windows>.  
+To download the windows version of osm2pgsql, navigate your web browser to <https://wiki.openstreetmap.org/wiki/Osm2pgsql#Windows>.  
 
 ![windows binary][]
 
@@ -133,9 +133,9 @@ Summary
 
 When you want to import OpenStreetMap data into your own database, **osm2pgsql** is a great tool. It can be extremely useful when you need to be able to get the most up-to-date OSM data and customize the attributes you want, or when working on more complex projects.  
 
-Another import tool has been developed recently, called [imposm](http://imposm.org/), and offers some speed and other improvements over osm2pgsql, although as of this writing it lacks other key functions which are promised in imposom version 3.  
+Another import tool has been developed recently, called [imposm](https://imposm.org/), and offers some speed and other improvements over osm2pgsql, although as of this writing it lacks other key functions which are promised in imposom version 3.  
 
-For more information on osm2pgsql, refer to the OSM Wiki - <http://wiki.openstreetmap.org/wiki/Osm2pgsql>.  
+For more information on osm2pgsql, refer to the OSM Wiki - <https://wiki.openstreetmap.org/wiki/Osm2pgsql>.  
 
 
 [windows binary]: /images/osm-data/windows-binary.png

--- a/_posts/en/0600-12-10-setting-up-postgresql_en.md
+++ b/_posts/en/0600-12-10-setting-up-postgresql_en.md
@@ -16,7 +16,7 @@ In this chapter we will see how to set up PostgreSQL on Windows and how to creat
 Installing PostgreSQL and PostGIS
 ----------------------------------
 
-In this section we will install PostgreSQL and then add the PostGIS spatial extensions. This is fairly easy to setup using the One-Click Installer. Navigate your web browser to the PostgreSQL website and the download page <http://www.postgresql.org/download/>  
+In this section we will install PostgreSQL and then add the PostGIS spatial extensions. This is fairly easy to setup using the One-Click Installer. Navigate your web browser to the PostgreSQL website and the download page <https://www.postgresql.org/download/>  
 
 ![postgresql website][]
 
@@ -128,7 +128,7 @@ Make sure that your new database is selected in the panel on the left and go to 
 
 ![add shapefile][]
 
-Now let's load the data from our database into the QGIS application. If you don't have QGIS you can download it on the [QGIS website](http://www.qgis.org/site/forusers/download.html).  
+Now let's load the data from our database into the QGIS application. If you don't have QGIS you can download it on the [QGIS website](https://www.qgis.org/site/forusers/download.html).  
 
 -	Open QGIS and click the ![qgis add postgis button][]{: height="24px"} button.  
 -	Under “Connections” at the top, click “**New**.”  

--- a/_posts/en/0600-12-13-osm-in-qgis_en.md
+++ b/_posts/en/0600-12-13-osm-in-qgis_en.md
@@ -13,7 +13,7 @@ Using OSM Data in QGIS
 
 QGIS (formerly Quantum GIS) is a full-featured, open-source, cross-platform Geographic Information System. With QGIS you can access up-to-date OSM data whenever you want, select the tags you want to include, and easily export it into an easy-to-use SQLite database or Shapefile.  
 
-In this chapter we'll walk through the steps necessary to do this. We assume that you've already downloaded and installed QGIS 3.x. If you haven't already done this, you can download it from <http://www.qgis.org/en/site/forusers/download.html>.  
+In this chapter we'll walk through the steps necessary to do this. We assume that you've already downloaded and installed QGIS 3.x. If you haven't already done this, you can download it from <https://www.qgis.org/en/site/forusers/download.html>.  
 
 We will use a plugin, QuickOSM, to import data from the OpenStreetMap database. To install this plugin open the Manage Plugins dialogue from the Plugins menu. Search for QuickOSM and install it. This will add an entry to the Vector menu  
 

--- a/_posts/en/0600-12-14-geofabrik-and-hotexport_en.md
+++ b/_posts/en/0600-12-14-geofabrik-and-hotexport_en.md
@@ -11,12 +11,12 @@ Using Geofabrik and HOT Export
 
 > Reviewed 2016-09-05  
 
-After learning how to add and edit data in OpenStreetMap (OSM), now maybe you would like to obtain the data as a backup or to process it using Geographic Information System software that is Open Source, such as Quantum GIS ([www.qgis.org](http://www.qgis.org)).  
+After learning how to add and edit data in OpenStreetMap (OSM), now maybe you would like to obtain the data as a backup or to process it using Geographic Information System software that is Open Source, such as Quantum GIS ([www.qgis.org](https://www.qgis.org)).  
 
 Getting OSM Data on Geofabrik Website
 -------------------------------------
 
-The OSM data can be obtained easily by downloading it from [http://download.geofabrik.de/openstreetmap/](http://download.geofabrik.de/openstreetmap/)
+The OSM data can be obtained easily by downloading it from [https://download.geofabrik.de/openstreetmap/](https://download.geofabrik.de/openstreetmap/)
 
 ![download-geofabrik][]
 
@@ -74,7 +74,7 @@ The last two ways in which an AOI can be selected is through the ‘This View’
 ![export-tool-area-import1][]
 
 
-The imported polygon must be a GeoJSON file in WGS84 geographic coordinates. One of the ways to create a GeoJSON file is to use the geojson.io site. Once the area has been selected in [geojson.io](http://geojson.io/), copy the text in the box to the right, paste it into an editor of choice, such as [Atom](https://atom.io/) and save your GeoJSON file.
+The imported polygon must be a GeoJSON file in WGS84 geographic coordinates. One of the ways to create a GeoJSON file is to use the geojson.io site. Once the area has been selected in [geojson.io](https://geojson.io/), copy the text in the box to the right, paste it into an editor of choice, such as [Atom](https://atom.io/) and save your GeoJSON file.
 
 ![export-tool-geojson-io][]
 ![export-tool-geojson-edit1][]

--- a/_posts/en/0600-12-15-getting-data_en.md
+++ b/_posts/en/0600-12-15-getting-data_en.md
@@ -28,11 +28,11 @@ They are accessible to everyone, with or without a Tasking Manager account.
 
 ### GeoFabrik
 
-[GeoFabrik](http://geofabrik.de) is a company which specializes in working with OpenStreetMap. They provide a variety of free extracts in  shapefile and raw OSM format on their [download website](http://download.geofabrik.de). The advantage of downloading GeoFabrik data is that it  is updated every day, and it's easy and reliable. One disadvantage is that the data is extracted by country, and not all countries are  available.  
+[GeoFabrik](https://geofabrik.de) is a company which specializes in working with OpenStreetMap. They provide a variety of free extracts in  shapefile and raw OSM format on their [download website](https://download.geofabrik.de). The advantage of downloading GeoFabrik data is that it  is updated every day, and it's easy and reliable. One disadvantage is that the data is extracted by country, and not all countries are  available.  
 
 ### BBBike  
 
-[BBBike](http://download.bbbike.org/osm/bbbike/) provides shapefiles and raw OSM format for cities around the world, extracted weekly. This is  useful if you are looking for data extracts for a single city.
+[BBBike](https://download.bbbike.org/osm/bbbike/) provides shapefiles and raw OSM format for cities around the world, extracted weekly. This is  useful if you are looking for data extracts for a single city.
 
 >Remember that features in OpenStreetMap have an unlimited number of "free" tags,
 >but shapefiles have attributes stored in a limited number of columns. This means
@@ -47,13 +47,13 @@ Customized Extracts
 
 ### HOT Exports  
 
-The [Humanitarian OpenStreetMap Team](http://hotosm.org) has created a service that allows users to select the area that they want to extract,  and also use [JOSM Presets](/en/josm/josm-presets/) to select custom tags to be included in the extract. The service is available to all  countries where HOT works, at [export.hotosm.org](http://export.hotosm.org).
+The [Humanitarian OpenStreetMap Team](https://hotosm.org) has created a service that allows users to select the area that they want to extract,  and also use [JOSM Presets](/en/josm/josm-presets/) to select custom tags to be included in the extract. The service is available to all  countries where HOT works, at [export.hotosm.org](https://export.hotosm.org).
 
 ![hot exports][]
 
 ### BBBike  
 
-You can select your own area from any part of the world using the service at [http://extract.bbbike.org/](http://extract.bbbike.org/).  Disadvantages are that you aren't able to select customizable tags and that the amount of data which you can download is limited.  
+You can select your own area from any part of the world using the service at [https://extract.bbbike.org/](https://extract.bbbike.org/).  Disadvantages are that you aren't able to select customizable tags and that the amount of data which you can download is limited.  
 
 ### Overpass
 
@@ -61,7 +61,7 @@ Overpass is an API (Application Programming Interface) for extracting data from 
 
 #### Overpass Turbo
 
-[Overpass Turbo](http://overpass-turbo.eu/) is an interactive query generator where you should first zoom to the appropriate region on the map. Enter your query in the left field of the page and trigger any actions using the buttons at the top of the interface. If you are new to the query language then using the wizard should get you started. The OSM wiki contains a [full description](http://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL) of the syntax of the query language as well as a [collection of examples](http://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_API_by_Example).
+[Overpass Turbo](http://overpass-turbo.eu/) is an interactive query generator where you should first zoom to the appropriate region on the map. Enter your query in the left field of the page and trigger any actions using the buttons at the top of the interface. If you are new to the query language then using the wizard should get you started. The OSM wiki contains a [full description](https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL) of the syntax of the query language as well as a [collection of examples](https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_API_by_Example).
 
 The map will highlight all data selected by your query which you can then modify. Press "Run" to refresh the result display. Once you are satisfied with what you see then "Export" offers a number of choices, among them raw OSM data. If the amount of data is limited you may as well access them directly after switching between map view and data view using the rightmost buttons at the top. The export option *Query -> compact OverpassQL* generates a hyperlink to be used for the Overpass API.
 
@@ -71,7 +71,7 @@ If you want to engineer a fancy query in order to obtain a subset of the data fr
 
 #### Overpass API
 
-[Overpass API](http://wiki.openstreetmap.org/wiki/Overpass_API) is a dedicated service optimized for querying but not writing OpenStreetMap data. Due to this optimization it operates very fast compared to the main database api and has virtually no limits on the amount of data transferred. Several instances of this service are available on the net, the one used in the following example also provides some information on [its homepage](http://overpass-api.de/)
+[Overpass API](https://wiki.openstreetmap.org/wiki/Overpass_API) is a dedicated service optimized for querying but not writing OpenStreetMap data. Due to this optimization it operates very fast compared to the main database api and has virtually no limits on the amount of data transferred. Several instances of this service are available on the net, the one used in the following example also provides some information on [its homepage](https://overpass-api.de/)
 
 If you have a working query-URL for submitting an http-request to the Overpass API then a tool such as [wget](https://www.gnu.org/software/wget/) - available for different operating systems, see [here](http://wget.addictivecode.org/FrequentlyAskedQuestions?action=show&redirect=Faq#download) - allows you to download the raw OSM data directly from the server and store them locally. The following snippet is a script for the bash shell common on Unix systems which obtains all data within a specified bounding box:
 
@@ -86,7 +86,7 @@ echo upper_right longitude
 read ur_lon
 echo output file
 read file
-url="http://overpass-api.de/api/interpreter?data=(node($ll_lat,$ll_lon,$ur_lat,$ur_lon);<;rel(br););out meta;"
+url="https://overpass-api.de/api/interpreter?data=(node($ll_lat,$ll_lon,$ur_lat,$ur_lon);<;rel(br););out meta;"
 wget -O $file "$url"
 ```
 >What happens here (for the curious who do not want to read the full query language documentation)?  

--- a/_posts/en/0600-12-30-data-overview_en.md
+++ b/_posts/en/0600-12-30-data-overview_en.md
@@ -29,7 +29,7 @@ Using Geodata
 If you are not an experienced GIS user, it's important to understand the difference between OSM editing software like JOSM and GIS software such as Quantum GIS and ArcGIS.  
 
 Editors such as iD or JOSM have one core function that they are very good at - making it easy for users to edit OpenStreetMap. But they are not software meant for analyzing or querying data -
-this function is best left to other applications. GIS software, such as the free and open source [Quantum GIS (QGIS)](http://www.qgis.org), allows users to design good-looking maps, to query and analyze data, and much more. GIS software can also be used for editing geodata, but it is much easier to edit OpenStreetMap with the dedicated OSM editors.  
+this function is best left to other applications. GIS software, such as the free and open source [Quantum GIS (QGIS)](https://www.qgis.org), allows users to design good-looking maps, to query and analyze data, and much more. GIS software can also be used for editing geodata, but it is much easier to edit OpenStreetMap with the dedicated OSM editors.  
 
 In the next chapter we will take a closer look at file formats which are associated with OpenStreetMap and geographic data in general. Then we'll look at various ways to access and manipulate OSM data and convert it between different file types.  
 

--- a/_posts/en/0900-12-03-gpslogger_en.md
+++ b/_posts/en/0900-12-03-gpslogger_en.md
@@ -19,7 +19,7 @@ A simple, light-weight, and minimalistic app for recording GPS traces on the And
 
 GPSLogger for Android is an app that is free to use, and an actively maintained open source project. Donations are welcomed to further enhance the app. If you wish to get involved (e.g. providing translations in another language, bug reporting, or submitting feature requests), visit the [repository](https://github.com/mendhak/gpslogger).  
 
-> OpenGTS refers to the [Open GPS Tracking System](http://opengts.sourceforge.net/) project  
+> OpenGTS refers to the [Open GPS Tracking System](https://opengts.sourceforge.net/) project  
 
 
 Features
@@ -228,9 +228,9 @@ Connect your Android device to a computer (also possible using a data cable, Blu
 
 Using the GPX tracks with the JOSM and iD editors are easy as dragging the files and dropping them into the application (or the browser tab, for iD).  
 
-For additional details for  iD users, see the section [Configuring the Background Layer](http://learnosm.org/en/beginner/id-editor/#configuring-the-background-layer).  
+For additional details for  iD users, see the section [Configuring the Background Layer](https://learnosm.org/en/beginner/id-editor/#configuring-the-background-layer).  
 
-If the JOSM editor is used, you can find instructions on how to use the GPX track, along with the multimedia files in JOSM see the section [Open in JOSM](http://learnosm.org/en/mobile-mapping/using-gps/#open-in-josm).  
+If the JOSM editor is used, you can find instructions on how to use the GPX track, along with the multimedia files in JOSM see the section [Open in JOSM](https://learnosm.org/en/mobile-mapping/using-gps/#open-in-josm).  
 
 For other OpenStreetMap editors, please refer to your software’s documentation.  
 
@@ -268,7 +268,7 @@ This section introduced the concept of using GPSLogger for Android for collectin
 Official GPSLogger for Android Documentation
 --------------------------------------------
 
-The project maintains an [FAQ](http://code.mendhak.com/gpslogger/#faq) for commonly asked questions.
+The project maintains an [FAQ](https://code.mendhak.com/gpslogger/#faq) for commonly asked questions.
 
 [GPSLogger]: /images/mobile-mapping/gpslogger_000.en.png
 [Canvass1]: /images/mobile-mapping/gpslogger_001.en.png

--- a/_posts/en/0900-12-04-basicairdata-gpslogger_en.md
+++ b/_posts/en/0900-12-04-basicairdata-gpslogger_en.md
@@ -66,8 +66,8 @@ You can use this simple 2-step procedure:
 Official Documentation
 ----------------------
 
-- For further information about this app you can read [this article](http://www.basicairdata.eu/projects/android/android-gps-logger/).<br>
-- [Here](http://www.basicairdata.eu/projects/android/android-gps-logger/getting-started-guide-for-gps-logger/) you can find a Getting Started Guide and an Overview of the App Settings.<br>
+- For further information about this app you can read [this article](https://www.basicairdata.eu/projects/android/android-gps-logger/).<br>
+- [Here](https://www.basicairdata.eu/projects/android/android-gps-logger/getting-started-guide-for-gps-logger/) you can find a Getting Started Guide and an Overview of the App Settings.<br>
 - Problems during use or configuration of GPS Logger? Read the [Frequently Asked Questions](https://github.com/BasicAirData/GPSLogger/blob/master/readme.md#frequently-asked-questions) page!
 
 [BasicAirData-GPSLogger-002]:  /images/mobile-mapping/basicairdata-gpslogger_002.en.jpg

--- a/_posts/en/0900-12-10-oruxmaps_en.md
+++ b/_posts/en/0900-12-10-oruxmaps_en.md
@@ -38,7 +38,7 @@ In OruxMaps, you can choose whether you want to use online maps or offline maps.
 
 ![Interface overview][]
 
-Source: [OruxMaps Manual English Version](http://www.google.com/url?q=http%3A%2F%2Fwww.oruxmaps.com%2Foruxmapsmanual_en.pdf&sa=D&sntz=1&usg=AFQjCNFY7Tk-Gzz9NFKy9WOsnfnn8x3Kwg)  
+Source: [OruxMaps Manual English Version](https://www.google.com/url?q=http%3A%2F%2Fwww.oruxmaps.com%2Foruxmapsmanual_en.pdf&sa=D&sntz=1&usg=AFQjCNFY7Tk-Gzz9NFKy9WOsnfnn8x3Kwg)  
 This manual may be more up to date than this guide, and may be available in other languages.  
 
 You can change your background map under **Maps \> Switch Maps**. After that you get to options - you want to use your **Online Map** or you want to use

--- a/_posts/en/0900-12-20-osmand2_en.md
+++ b/_posts/en/0900-12-20-osmand2_en.md
@@ -22,12 +22,12 @@ The iOS version is available from iTunes.
 
 <a href="https://itunes.apple.com/app/id934850257">
   <img alt="OsmAnd Maps on iTunes"
-       src="http://linkmaker.itunes.apple.com/images/badges/en-us/badge_appstore-lrg.png" />
+       src="https://linkmaker.itunes.apple.com/images/badges/en-us/badge_appstore-lrg.png" />
 </a>
 
->Some of OsmAnd's Android platform features may not yet be available on the iOS edition. See the developers' [blog site](http://osmand.net/blog) for details.  
+>Some of OsmAnd's Android platform features may not yet be available on the iOS edition. See the developers' [blog site](https://osmand.net/blog) for details.  
 
-In addition to the above sources, a community-maintained version is available from [F-Droid](https://f-droid.org/app/net.osmand.plus), or through third-party software sources like [Amazon](http://www.amazon.com/OsmAnd-Maps-Navigation/dp/B00D0SA8I8).  
+In addition to the above sources, a community-maintained version is available from [F-Droid](https://f-droid.org/app/net.osmand.plus), or through third-party software sources like [Amazon](https://www.amazon.com/OsmAnd-Maps-Navigation/dp/B00D0SA8I8).  
 
 Getting Started
 ---------------
@@ -52,7 +52,7 @@ To download a geographic region database, select *All Downloads* tab and type in
 
 After selecting the files, press the download button at the options button. Depending on your Internet connection or the number of files selected, this may take several minutes.  When you've downloaded the files, you're all set for OsmAnd's offline mode.  
 
-> One of the unique features of the community version from F-Droid is the unlimited frequency of downloads you may do from the app itself. The free-to-use Play store version is limited to just ten downloads. A work-around to this limitation is to download the database from [http://download.osmand.net/rawindexes/](http://download.osmand.net/rawindexes/) to your PC, and transfer them manually to your device.  
+> One of the unique features of the community version from F-Droid is the unlimited frequency of downloads you may do from the app itself. The free-to-use Play store version is limited to just ten downloads. A work-around to this limitation is to download the database from [https://download.osmand.net/rawindexes/](https://download.osmand.net/rawindexes/) to your PC, and transfer them manually to your device.  
 
 The pre-fabricated databases that were just downloaded are also referred to as "Vector Maps", and are stored in the .obf format. They are compact, and allow offline users to zoom in at great detail.  
 
@@ -268,7 +268,7 @@ Using the GPX tracks with the JOSM and iD editors are easy as dragging the files
 Using OsmAnd with FieldPapers and JOSM
 --------------------------------------
 
-[FieldPapers](http://fieldpapers.org) is one of the favorite, "low-tech" tools used by many mappers. [Here is the LearnOSM training material for FieldPapers](/en/mobile-mapping/field-papers/).  
+[FieldPapers](https://fieldpapers.org) is one of the favorite, "low-tech" tools used by many mappers. [Here is the LearnOSM training material for FieldPapers](/en/mobile-mapping/field-papers/).  
 
 > The following protcol was developed during a field mapping activity from Bangladesh. See original post [here](https://wiki.openstreetmap.org/wiki/Field_Papers#How_to_use_with_OsmAnd).  
 
@@ -294,9 +294,9 @@ This section introduced the concept of using OsmAnd for collecting GPX tracks, m
 Official OsmAnd Documentation
 -------------------
 
-Additional reference materials are available from the [help](http://osmand.net/help/) section of OsmAnd's website.  
+Additional reference materials are available from the [help](https://osmand.net/help/) section of OsmAnd's website.  
 
-Details about the legend in use in the default map style, is in their [Extended Online Knowledge Base](http://osmand.net/help-online/map-legend).  
+Details about the legend in use in the default map style, is in their [Extended Online Knowledge Base](https://osmand.net/help-online/map-legend).  
 
 [Canvass Elements]: /images/mobile-mapping/osmand2_000.png
 [Long Press Pop-up]: /images/mobile-mapping/osmand2_001a.png

--- a/_posts/en/0900-12-23-papers_en.md
+++ b/_posts/en/0900-12-23-papers_en.md
@@ -11,7 +11,7 @@ Surveying with Field Papers
 
 > Reviewed 2016-08-10  
 
-In this chapter we will see how we can record the coordinates of places without a GPS. We will use a tool called [Field Papers](http://fieldpapers.org/), which allows you to print a map of an area, draw on it and add notes, and load the paper back into JOSM, where you can add your locations to OpenStreetMap. You can also watch this 8-minute [Tutorial Field Papers video](http://www.youtube.com/watch?v=A_HGkBXZ69g&feature=youtu.be) on how to create an atlas and upload a snapshot.  
+In this chapter we will see how we can record the coordinates of places without a GPS. We will use a tool called [Field Papers](https://fieldpapers.org/), which allows you to print a map of an area, draw on it and add notes, and load the paper back into JOSM, where you can add your locations to OpenStreetMap. You can also watch this 8-minute [Tutorial Field Papers video](https://www.youtube.com/watch?v=A_HGkBXZ69g&feature=youtu.be) on how to create an atlas and upload a snapshot.  
 
 Overview of Field Papers
 --------------------------
@@ -43,7 +43,7 @@ Now let's learn how to create and use Field Papers.
 Create and Print
 ----------------
 
-Open your web browser. In the address bar at the top of the window, enter the following text and press Enter: [fieldpapers.org](http://fieldpapers.org)
+Open your web browser. In the address bar at the top of the window, enter the following text and press Enter: [fieldpapers.org](https://fieldpapers.org)
 The website should look something like this:  
 
 ![FieldPapers homepage][]
@@ -147,7 +147,7 @@ Before we can open the Field Paper in JOSM, we need to install the JOSM Field Pa
 Open in JOSM
 ------------
 
-Now can load your Field Paper into JOSM and use it to add the information you collected to OpenStreetMap. Unless you still have the web page with your snapshots open or stored a bookmark to it, return to the Field Papers website, by typing [fieldpapers.org](http://fieldpapers.org/) in your web browser, just as before.  
+Now can load your Field Paper into JOSM and use it to add the information you collected to OpenStreetMap. Unless you still have the web page with your snapshots open or stored a bookmark to it, return to the Field Papers website, by typing [fieldpapers.org](https://fieldpapers.org/) in your web browser, just as before.  
 - Click the "Watch" tab and then click "Snapshots."  
 - Find your paper from the list, and click on it. You should see something like this:  
 
@@ -155,7 +155,7 @@ Now can load your Field Paper into JOSM and use it to add the information you co
 
 To load the paper into JOSM, we need to copy the snapshot ID of the Field Papers you have scanned. In the URL bar at the top of your internet browser, select the text and press CTRL+C on your keyboard to copy. The text should look similar to this:  
 
-[http://fieldpapers.org/snapshot.php?id=zqw8m33x#16/14.6582/121.1098](http://fieldpapers.org/snapshot.php?id=zqw8m33x#16/14.6582/121.1098)
+[https://fieldpapers.org/snapshot.php?id=zqw8m33x#16/14.6582/121.1098](https://fieldpapers.org/snapshot.php?id=zqw8m33x#16/14.6582/121.1098)
 
 ![Fieldpaper ID][]
 

--- a/_posts/en/0900-12-25-gps_en.md
+++ b/_posts/en/0900-12-25-gps_en.md
@@ -54,7 +54,7 @@ Navigate the GPS
 
 -   Flip to the Map page, and you can see a map of where you are. If you have added OSM maps to your GPS, you may see roads and places. Otherwise, the map may look quite blank. Zoom in and out by pressing the up and down arrow buttons on the left side of the GPS.
 
--   Further information where to obtain OSM maps for Garmin devices and how to install them can be found [in the OSM wiki](http://wiki.openstreetmap.org/wiki/OSM_Map_On_Garmin/Download)
+-   Further information where to obtain OSM maps for Garmin devices and how to install them can be found [in the OSM wiki](https://wiki.openstreetmap.org/wiki/OSM_Map_On_Garmin/Download)
 
 Tracks and Waypoints
 --------------------
@@ -106,7 +106,7 @@ Copy Waypoints and Tracks to the Computer
 -----------------------------------------
 When you are finished mapping with the GPS you will want to copy the points and tracks to your computer so that you can open them in JOSM.
 
-One way to copy the waypoints and tracks is to you use the free software that Garmin provides, called BaseCamp. It can be downloaded [here](http://www.garmin.com/en-US/shop/downloads/basecamp). However, in this section we will use a program called GPSBabel, which offers a few additional features.
+One way to copy the waypoints and tracks is to you use the free software that Garmin provides, called BaseCamp. It can be downloaded [here](https://www.garmin.com/en-US/shop/downloads/basecamp). However, in this section we will use a program called GPSBabel, which offers a few additional features.
 
 ### Attach GPS to the Computer
 -   First, turn off the track log on your GPS, by going to the track page and selecting “Off”.
@@ -114,14 +114,14 @@ One way to copy the waypoints and tracks is to you use the free software that Ga
 
 ### Install GPS Drivers
 
--   You may need to install GPS drivers on your computer. You can download the drivers at the [Garmin Website](http://www8.garmin.com/support/download_details.jsp?id=591).
+-   You may need to install GPS drivers on your computer. You can download the drivers at the [Garmin Website](https://www8.garmin.com/support/download_details.jsp?id=591).
 -   Click “Download” to get the installation file. Locate it on your computer, and double-click to install.
 
 > Linux systems (at least Fedora) do not need special drivers to communicate with a Garmin device (at least the eTrex Vista HCx). Just make sure that your Garmin is powered and plug it into your compure with a USB cable. You can use GPSBabel (as instructed below) or GpsPrune to grab the saved data from your device.
 
 ### Get the GPSBabel Setup Program
 -   GPSBabel is a program that allows us to copy data from the GPS. If you have a copy of GPSBabel on a CD or usb flash drive, you can skip to the next section.
--   If you don’t have GPSbabel already, open your web browser and go to [www.gpsbabel.org](http://www.gpsbabel.org)
+-   If you don’t have GPSbabel already, open your web browser and go to [www.gpsbabel.org](https://www.gpsbabel.org)
 -   Click “Downloads” at the top of the page.
 -   Scroll down the page. If your computer uses Windows, you want to download the installation file for Windows. Click “GPSBabel-1.5.2-Setup.exe”. The file will be downloaded to your computer.
 

--- a/_posts/en/1900-02-15-josm-conflict-resolution_en.md
+++ b/_posts/en/1900-02-15-josm-conflict-resolution_en.md
@@ -126,8 +126,8 @@ The values you've chosen will be applied and the dialog will be closed.
 
 If you see the symbol ![]({{site.baseurl}}/images/intermediate/en_conflict_resolution_image08.png)in the tab Nodesthen you
 have to resolve differences in the list of
-[nodes](http://josm.openstreetmap.de/wiki/Help/Concepts/Object)of two
-[ways](http://josm.openstreetmap.de/wiki/Help/Concepts/Object). There
+[nodes](https://josm.openstreetmap.de/wiki/Help/Concepts/Object)of two
+[ways](https://josm.openstreetmap.de/wiki/Help/Concepts/Object). There
 are three columns in the respective panel (see screen shot below):
 
 1.  the leftmost table displays the list of nodes of the the local
@@ -146,7 +146,7 @@ server dataset (the rightmost table).
 
 The standard workflow to resolve conflicts in the node lists of two
 [object
-versions](http://josm.openstreetmap.de/wiki/Help/Concepts/Object)consists
+versions](https://josm.openstreetmap.de/wiki/Help/Concepts/Object)consists
 of three steps:
 
 1.  Pick nodes from either object version and reorder the resulting node

--- a/_posts/en/1900-03-15-correcting-imagery-offset_en.md
+++ b/_posts/en/1900-03-15-correcting-imagery-offset_en.md
@@ -138,9 +138,9 @@ Oh No!  Somebody mapped this area with misaligned imagery, so the area is not co
 Imagery Offset Database Website
 --------------------------------
 
-Lastly, for more information on the offset database, you can visit the website at [http://offsets.textual.ru/](http://offsets.textual.ru/).  This lists all the offsets that have been uploaded to the database, and it also has a cool map feature that visualizes where the offsets are located, as you can see here:  
+Lastly, for more information on the offset database, you can visit the website at [https://offsets.textual.ru/](https://offsets.textual.ru/).  This lists all the offsets that have been uploaded to the database, and it also has a cool map feature that visualizes where the offsets are located, as you can see here:  
 
-![http://offsets.textual.ru/][]
+![https://offsets.textual.ru/][]
 
 > One last thing to remember is that the imagery may not be offset the same distance everywhere!  This is especially true in regions where there are lots of hills and mountains.  So if the imagery seems to be offset differently in different areas, you’ll need to move it again.  
 
@@ -171,7 +171,7 @@ When you are just beginning OpenStreetMap, you don’t need to worry too much ab
 [Store imagery offset]: /images/josm/store-imagery-offset.png
 [Offset description]: /images/josm/offset-description.png
 [Corrected imagery]: /images/josm/correctly-placed.png
-[http://offsets.textual.ru/]: /images/josm/offset-website.png
+[https://offsets.textual.ru/]: /images/josm/offset-website.png
 
 
 

--- a/_posts/en/1900-04-10-adding-imagery_en.md
+++ b/_posts/en/1900-04-10-adding-imagery_en.md
@@ -13,7 +13,7 @@ JOSM - Adding Aerial Imagery
 
 Not all aerial imagery is within the JOSM imagery menu, but it is easy to add if you have been given the link information.  
 
-In this example we are working from the [HOT Tasking Manager](http://tasks.hotosm.org/) and the imagery required to complete one of the projects needs to be manually added to JOSM. The principle of adding the image link is the same whatever the editing you are working on, as long as you are provided with the link. There are also occasions when the intended links do not work as expected and it may be necessary to add the imagery manually, if you can obtain the link information.  
+In this example we are working from the [HOT Tasking Manager](https://tasks.hotosm.org/) and the imagery required to complete one of the projects needs to be manually added to JOSM. The principle of adding the image link is the same whatever the editing you are working on, as long as you are provided with the link. There are also occasions when the intended links do not work as expected and it may be necessary to add the imagery manually, if you can obtain the link information.  
 
 From the Tasking Manager information tab, or your other source of the information, copy all of the Imagery section.  
 
@@ -65,7 +65,7 @@ The resulting dialog box will look like the one below:
 **Box 5.** This is auto generated after you select a layer in **Box 3**. It will be long and complicated, usually it is just fine and is more informational and typically should not be edited.  
 **Box 6.** Enter a name for the server or layer. A default name will be filled in based on the URL, but you can enter a more meaningful name. This is the name that will appear in the JOSM Imagery menu when you want to add the layer to your layers panel in the regular JOSM interface.  
 
-> Example WMS server with a lot of interesting layers: http://sedac.ciesin.columbia.edu/geoserver/wms  
+> Example WMS server with a lot of interesting layers: https://sedac.ciesin.columbia.edu/geoserver/wms  
 
 ![wms_select_layer_highlighted][]  
 Make sure you actually click on a layer if you would like to have the Imagery menu item always load the same layer. In the above example, when the layer is selected from the Imagery Menu, it will always load the "World Database of Protected Areas" layer.

--- a/_posts/en/1900-06-15-josm-relations_en.md
+++ b/_posts/en/1900-06-15-josm-relations_en.md
@@ -62,7 +62,7 @@ When you create a multipolygon like this it will be rendered on the map like so:
 
 ![Multipolygon in Mapnik][]
 
-Multipolygons can be used for any complex object that requires inner and outer polygons, like a building or a river with patches of land inside it. Detailed multipolygon information can be found on the [OSM Wiki](http://wiki.openstreetmap.org/wiki/Relation:multipolygon).  
+Multipolygons can be used for any complex object that requires inner and outer polygons, like a building or a river with patches of land inside it. Detailed multipolygon information can be found on the [OSM Wiki](https://wiki.openstreetmap.org/wiki/Relation:multipolygon).  
 
 Route Relations
 ----------------

--- a/_posts/en/1900-07-15-creating-custom-presets_en.md
+++ b/_posts/en/1900-07-15-creating-custom-presets_en.md
@@ -120,11 +120,11 @@ Creating Your Own Presets File
 
 The best way to create your own presets file is to take one that already exists, and manipulate it fulfill your objectives.  Feel free to edit this sample file and experiment with it to learn the basics. Just remember that each time you save it, you will need to restart JOSM to load the changes.  
 
-Before you start creating your own presets, you need to think carefully about the tags that you will use. Inventing new tags is another topic altogether. Generally, you should utilize existing OSM tags when they exist. Most existing tags are listed on the [Map Features page on the OSM Wiki](http://wiki.openstreetmap.org/wiki/Map_Features).  
+Before you start creating your own presets, you need to think carefully about the tags that you will use. Inventing new tags is another topic altogether. Generally, you should utilize existing OSM tags when they exist. Most existing tags are listed on the [Map Features page on the OSM Wiki](https://wiki.openstreetmap.org/wiki/Map_Features).  
 
 This sample file contains most of the elements that you will find in a JOSM presets file - there aren't very many form elements. If you'd like to experiment with a more complex presets file, download the [dhaka_presets.xml](/files/dhaka_presets.xml) file here.  
 
-Additionally, a detailed explanation of all possible elements can be found [here](http://josm.openstreetmap.de/wiki/TaggingPresets).  
+Additionally, a detailed explanation of all possible elements can be found [here](https://josm.openstreetmap.de/wiki/TaggingPresets).  
 
 Good luck!  
 

--- a/_posts/en/1900-09-25-josm-more-plugins-2_en.md
+++ b/_posts/en/1900-09-25-josm-more-plugins-2_en.md
@@ -38,7 +38,7 @@ Preparing the spreadsheet
 
 The wiki page at <https://wiki.openstreetmap.org/wiki/JOSM/Plugins/OpenData> provides more detailed information about formats which can be used. For our purposes we are assuming that the spreadsheet has been downloaded and passed to us in the proprietry **.xlsx** which will not load into the opendata plugin.  
 
-- Open the spreadsheet in an opensource programme such as LibreOffice which is available for most operating systems <http://www.libreoffice.org/>,  
+- Open the spreadsheet in an opensource programme such as LibreOffice which is available for most operating systems <https://www.libreoffice.org/>,  
 - and then save it in an opensource format. Our spreadsheet which was **shops.xlsx** becomes **shops.ods**.  
 
 Although it is possible to load the spreadsheet into josm now, it is better to carry out further amendments to make the process easier before doing so.  

--- a/_posts/en/1900-10-15-josm-plugins_en.md
+++ b/_posts/en/1900-10-15-josm-plugins_en.md
@@ -151,7 +151,7 @@ the \<\<Context\>\> menu.
 
 5. Now you can save the normal GPX layer as a file or upload the data to
 OSM (eg by using the
-plugin [DirectUpload](http://josm.openstreetmap.de/wiki/Plugins)).
+plugin [DirectUpload](https://josm.openstreetmap.de/wiki/Plugins)).
 
 Print
 -----
@@ -252,14 +252,14 @@ Uploading GPS Traces Online
 ---------------------------
 
 1. Go
-to [http://www.openstreetmap.org/](http://www.openstreetmap.org/) and log in.
+to [https://www.openstreetmap.org/](https://www.openstreetmap.org/) and log in.
 
 2. Select "GPS Traces" found on the left banner.
 
 ![Left Banner][]
 
 3. Select
-[upload a trace](http://www.openstreetmap.org/trace/create).
+[upload a trace](https://www.openstreetmap.org/trace/create).
 Here, you can also  **See just your traces** to review previous GPS tracks.  
 
 4. Find your file in "Choose File". Label it in the Description

--- a/_posts/en/1900-12-18-more-about-josm_en.md
+++ b/_posts/en/1900-12-18-more-about-josm_en.md
@@ -112,7 +112,7 @@ The third and final step to complete our edits is to upload the changes we have 
 
 See your changes on the map
 ---------------------------
--   Open your internet browser and go to [http://openstreetmap.org/](http://openstreetmap.org/)
+-   Open your internet browser and go to [https://openstreetmap.org/](https://openstreetmap.org/)
 -   Move the map to the area that you edited.
 -   You should see your changes now appearing on the map! If you don’t, try pressing CTRL+R to refresh the web page. Sometimes the browser still shows the old version and needs to be reloaded.
 -   What if you don’t see your changes? Don’t worry - it may take a few minutes for the changes to be shown on the map. Also, check your additions in JOSM to make sure that you added them correctly. A good general rule is, if your point has an icon in JOSM, then it should be seen on the main map at the OpenStreetMap website.

--- a/_posts/en/1900-12-21-start-josm_en.md
+++ b/_posts/en/1900-12-21-start-josm_en.md
@@ -18,7 +18,7 @@ Download JOSM
 -------------
 
 -   If you don’t have JOSM already, or want the newest version, open your web browser.
--   In the address bar at the top of the window, enter the following text and press Enter: [josm.openstreetmap.de](http://josm.openstreetmap.de)
+-   In the address bar at the top of the window, enter the following text and press Enter: [josm.openstreetmap.de](https://josm.openstreetmap.de)
 -   You can also find the JOSM website by searching the internet for “JOSM”.
 -   The website should look something like this:
 
@@ -33,9 +33,9 @@ Download JOSM
 Install JOSM
 ------------
 
->  You may have problems installing JOSM if Java is not already installed on your computer. If you have problems in this section, try downloading and installing Java. You can download it here: <http://www.java.com/en/download/>
+>  You may have problems installing JOSM if Java is not already installed on your computer. If you have problems in this section, try downloading and installing Java. You can download it here: <https://www.java.com/en/download/>
 >
->  Mac users may have old versions of Java. Please see <http://wiki.openstreetmap.org/wiki/JOSM/Mac#Installation> for options for OSX 10.6 and 10.7.3+
+>  Mac users may have old versions of Java. Please see <https://wiki.openstreetmap.org/wiki/JOSM/Mac#Installation> for options for OSX 10.6 and 10.7.3+
 
 -   Find the JOSM install file on your computer. Double-click it to begin setup.
 -   Click ‘OK’, ‘Next’, ‘I Agree’, and ‘Install’. When the installation is complete, click ‘Finish’ to launch JOSM for the first time. Later, when you want to start JOSM, you can do so by clicking on the Start Menu in the lower left corner of your computer, and clicking the program JOSM.

--- a/_posts/en/draft-0300-11-14-josm-adding-orbview-imagery_en.md
+++ b/_posts/en/draft-0300-11-14-josm-adding-orbview-imagery_en.md
@@ -92,7 +92,7 @@ area.
 
 ### A. Set up an account
 
-​Visit [http://earthexplorer.usgs.gov/](http://earthexplorer.usgs.gov/) and
+​Visit [https://earthexplorer.usgs.gov/](https://earthexplorer.usgs.gov/) and
 create an account.  Click the ¨Register¨ button on the top right.
 
 ![]({{site.baseurl}}/images/en/intermediate/en_int_ch3_image19.png)

--- a/_posts/en/draft-0450-10-07-enhance_en.md
+++ b/_posts/en/draft-0450-10-07-enhance_en.md
@@ -41,7 +41,7 @@ Installing the Stylish extension in Firefox
 4.  Install & restart.  
 ![Stylish-4][]
 
-5.  Visit <http://www.openstreetmap.org/> and click on the Stylish icon which will be present in your menu bar. Choose any useful extensions for installation & activate them as required using the menu from the Stylish icon.
+5.  Visit <https://www.openstreetmap.org/> and click on the Stylish icon which will be present in your menu bar. Choose any useful extensions for installation & activate them as required using the menu from the Stylish icon.
 ![Stylish-5][]
 
 6.  Purple traced buildings  
@@ -63,7 +63,7 @@ Installing the Stylish extension in Chrome
 4.  Install.  
 ![Stylish-chrome-4][]
 
-5.  Visit <http://www.openstreetmap.org/> and click on the Stylish icon which will be present in your menu bar. Choose any useful extensions for installation & activate them as required using the menu from the Stylish icon. You may have to select **Find more styles for this site** to find all of the available styles.  
+5.  Visit <https://www.openstreetmap.org/> and click on the Stylish icon which will be present in your menu bar. Choose any useful extensions for installation & activate them as required using the menu from the Stylish icon. You may have to select **Find more styles for this site** to find all of the available styles.  
 ![Stylish-chrome-5][]
 
 6.  Purple traced buildings is one of the options available. It may be worth checking back at intervals as more styles are developed.   

--- a/_posts/en/draft0450-01-10-validate_en.md
+++ b/_posts/en/draft0450-01-10-validate_en.md
@@ -20,11 +20,11 @@ Sending a link to a new mapper who does not know how to create round buildings
 
 The HOT Tips section that shows how to [create a round building using the iD editor is here](/en/hot-tips/tracing-round-buildings/). Your web browser will show the address as;  
 
-      http://learnosm.org/en/hot-tips/tracing-round-buildings/
+      https://learnosm.org/en/hot-tips/tracing-round-buildings/
 
 You can click on this in your web browser, highlight all of it, and then copy this for pasting into a link in the Tasking Manager.  
 
-Of course you may prefer to link to a guide on another site such as the tracing guides available at <http://hotosm.github.io/tracing-guides/> or even a user diary or some other source.  
+Of course you may prefer to link to a guide on another site such as the tracing guides available at <https://hotosm.github.io/tracing-guides/> or even a user diary or some other source.  
 
 ![validate][]
 

--- a/_posts/en/draft0500-11-26-quality-assurance_en.md
+++ b/_posts/en/draft0500-11-26-quality-assurance_en.md
@@ -162,7 +162,7 @@ map the entire grid
 To see how the tasking manager works, let’s take a closer look.
 
 1.  Open your Internet browser and go to
-    [tasks.hotosm.org](http://tasks.hotosm.org). You will see a page
+    [tasks.hotosm.org](https://tasks.hotosm.org). You will see a page
     like this:
 
     ![]({{site.baseurl}}/images/en/intermediate/en_quality_assurance_image02.png)

--- a/_posts/en/draft0500-11-28-editing_the_wiki_en.md
+++ b/_posts/en/draft0500-11-28-editing_the_wiki_en.md
@@ -21,13 +21,13 @@ OpenStreetMap wiki, a website where users can create different web pages
 about different topics and in different languages.  To see the OSM wiki,
 visit
 
-[http://wiki.openstreetmap.org](http://wiki.openstreetmap.org)
+[https://wiki.openstreetmap.org](https://wiki.openstreetmap.org)
 
 A wiki is a website where any user can add pages and edit existing
 pages.  It is based on the same principle as OpenStreetMap- the only
 difference is that with OSM users are editing maps, while wiki users are
 editing text.  The most famous wiki is Wikipedia
-([http://www.wikipedia.org),]() an online encyclopedia that covers
+([https://www.wikipedia.org),]() an online encyclopedia that covers
 almost every topic imaginable.
 
 The OpenStreetMap wiki contains information about everything related to
@@ -40,7 +40,7 @@ the OSM wiki pages, which describes all of the most common features that
 you can add to the map, and how they are commonly tagged.  This is the
 Map Features page:
 
-[http://wiki.openstreetmap.org/wiki/Map\_Features](http://wiki.openstreetmap.org/wiki/Map_Features)
+[https://wiki.openstreetmap.org/wiki/Map\_Features](https://wiki.openstreetmap.org/wiki/Map_Features)
 
 In this chapter we will learn how to add and edit pages on the OSM wiki.
  We will learn the guidlines for contributing, the special markup
@@ -52,7 +52,7 @@ wiki, such as translating important pages.
 
 ![]({{site.baseurl}}/images/en/intermediate/en_int_ch6_image09.png)
 
-Go to [http://wiki.openstreetmap.org](http://wiki.openstreetmap.org) to
+Go to [https://wiki.openstreetmap.org](https://wiki.openstreetmap.org) to
 see the main wiki page.  You’ll see a lot of things here, and many links
 to other pages on the wiki.  In the left column are links to some of the
 main pages.  At the top of the page are a list of all the languages in
@@ -287,7 +287,7 @@ Compare the wiki text to the way it is formatted when you are viewing
 it.
 
 You can find more information on editing at
-[http://wiki.openstreetmap.org/wiki/Help:Wiki-Editing](http://wiki.openstreetmap.org/wiki/Help:Wiki-Editing).
+[https://wiki.openstreetmap.org/wiki/Help:Wiki-Editing](https://wiki.openstreetmap.org/wiki/Help:Wiki-Editing).
 
 ​4.  Conventions and Guidelines
 ------------------------------
@@ -310,7 +310,7 @@ contribute.  Some key things to keep in mind are:
     spaces or dashes.  The Map Features page for example, is named
     Map\_Features, making the link:
 
-[http://wiki.openstreetmap.org/wiki/Map\_Features](http://wiki.openstreetmap.org/wiki/Map_Features)
+[https://wiki.openstreetmap.org/wiki/Map\_Features](https://wiki.openstreetmap.org/wiki/Map_Features)
 
 ### When Structuring a Page
 
@@ -341,18 +341,18 @@ The names of pages are always created in English, but different versions
 of the same page can be created by adding a language code into the URL.
  For example, the Map Features page is at
 
-[http://wiki.openstreetmap.org/wiki/Map\_Features](http://wiki.openstreetmap.org/wiki/Map_Features)
+[https://wiki.openstreetmap.org/wiki/Map\_Features](https://wiki.openstreetmap.org/wiki/Map_Features)
 
 If you want the Spanish version of this page, it is available at
 
-[http://wiki.openstreetmap.org/wiki/ES:Map\_Features](http://wiki.openstreetmap.org/wiki/ES:Map_Features)
+[https://wiki.openstreetmap.org/wiki/ES:Map\_Features](https://wiki.openstreetmap.org/wiki/ES:Map_Features)
 
 If a page exists that you want to translate, you simply visit the URL
 with your language code and a colon (:) preceding the page name.  For
 example, if we wanted to translate this page into Indonesian, we would
 visit
 
-[http://wiki.openstreetmap.org/wiki/ID:Map\_Features](http://wiki.openstreetmap.org/wiki/ID:Map_Features)
+[https://wiki.openstreetmap.org/wiki/ID:Map\_Features](https://wiki.openstreetmap.org/wiki/ID:Map_Features)
 
 Then we click “Edit” to create this page.
 

--- a/_posts/en/draft0600-12-12-converting-to-shapefile_en.md
+++ b/_posts/en/draft0600-12-12-converting-to-shapefile_en.md
@@ -15,11 +15,11 @@ Converting to Shapefile
 There are various tools that convert OSM data into shapefiles, each with its own pros and cons.  They all work via the command-line, so are best suited for those with a technical background.  Some of the tools are:
 osm2shp
 C++ application for converting OSM to shapefile.
-http://trac.openstreetmap.org/browser/applications/utils/export/osm2shp
+https://trac.openstreetmap.org/browser/applications/utils/export/osm2shp
 osmlib
 Ruby library for converting to OSM.  Hasn’t been maintained in a long time but still is functional.  Not good with very large datasets.  Easy to configure.
-http://wiki.openstreetmap.org/wiki/OSMLib
+https://wiki.openstreetmap.org/wiki/OSMLib
 ogr2ogr
 This library has recently added support for OSM, and can convert to all common geographic data formats.
-http://www.gdal.org/ogr/drv_osm.html
+https://www.gdal.org/ogr/drv_osm.html
 

--- a/_posts/en/draft0700-11-27-wms_en.md
+++ b/_posts/en/draft0700-11-27-wms_en.md
@@ -36,7 +36,7 @@ When we want to communicate the information, we will usually create some
 type of raster image. A raster image is just like a photograph. It may
 contain a lot of meaning, but it is impossible for us to analyze it or
 edit the different pieces. When you look at the map on
-[openstreetmap.org](http://www.openstreetmap.org/), you are looking at a
+[openstreetmap.org](https://www.openstreetmap.org/), you are looking at a
 bunch of raster images. These images are must smaller in size than the
 data that they are made from, and they are made to look nice. This
 makes it easy to view the map, but there is no way to access the
@@ -53,7 +53,7 @@ layers in QGIS, ArcGIS, and JOSM.
 ![]({{site.baseurl}}/images/en/advanced/en_adv_ch5_image19.png)
 
 In this chapter we will learn how to install and set up MapServer
-([http://www.mapserver.org/](http://www.mapserver.org/)), an open-source
+([https://www.mapserver.org/](https://www.mapserver.org/)), an open-source
 platform for publishing maps, and using it as our own WMS server.
 
 We will build on the previous tutorial in which we created a PostGIS
@@ -75,7 +75,7 @@ Install MapServer Software
 
 1. It is easy to install MapServer and the Apache webserver on Windows
    using the MS4W installer. You can download the installer at
-   [http://www.maptools.org/ms4w/](http://www.maptools.org/ms4w/).
+   [https://www.maptools.org/ms4w/](https://www.maptools.org/ms4w/).
    Click on the Downloads tab and get the ms4w_3.0.x.zip file.
    ![]({{site.baseurl}}/images/en/advanced/en_adv_ch5_image20.png)
 
@@ -355,7 +355,7 @@ image.
 In this chapter we learned how to set up MapServer and configure it as a
 WMS server, using the data that we imported into PostGIS to create map
 images. You can get more information on the WMS architecture at
-[http://docs.geoserver.org/latest/en/user/services/wms/reference.html](http://docs.geoserver.org/latest/en/user/services/wms/reference.html).
+[https://docs.geoserver.org/latest/en/user/services/wms/reference.html](https://docs.geoserver.org/latest/en/user/services/wms/reference.html).
 
 In the next chapters we will look at other ways of styling and
 transmitting maps across the internet. If you’re interested in

--- a/_posts/en/draft0700-11-28-github_en.md
+++ b/_posts/en/draft0700-11-28-github_en.md
@@ -25,7 +25,7 @@ GitHub and Repositories
 ----------------------------
 
 1. Navigate your web browser to
-   [http://www.github.com](http://www.github.com) and you will see the
+   [https://www.github.com](https://www.github.com) and you will see the
    home page of GitHub, the main online repository for storing
    git projects. Note the difference between github and git. Git is a
    control system that can make any folder on your computer a
@@ -243,5 +243,5 @@ versions than... or what to consider when  working together on one
 project using github..
 
 [[c]](#cmnt_ref3)Katrina Engelsted:
-Good source: http://nathanj.github.com/gitguide/tour.html
+Good source: https://nathanj.github.com/gitguide/tour.html
 --> 

--- a/_posts/en/draft0800-12-30-postgis_en.md
+++ b/_posts/en/draft0800-12-30-postgis_en.md
@@ -27,7 +27,7 @@ data set. For example, the OpenStreetMap server uses a database to
 store its map data. It uses the database to receive edits from mappers,
 to send small pieces of the map as XML to users, and to render the map
 as image tiles on the main website -
-[openstreetmap.org](http://www.openstreetmap.org).
+[openstreetmap.org](https://www.openstreetmap.org).
 
 ![]({{site.baseurl}}/images/en/advanced/en_adv_ch1_image02.png)
 
@@ -57,7 +57,7 @@ Installer.
 
 1. Navigate your web browser to the postgresql website and find the
    download page here: 
-   [http://www.postgresql.org/download/](http://www.postgresql.org/download/)
+   [https://www.postgresql.org/download/](https://www.postgresql.org/download/)
    ![]({{site.baseurl}}/images/en/advanced/en_adv_ch1_image29.png)
 
 2. From here you can find installation instructions for different
@@ -202,7 +202,7 @@ pgAdmin III is an easy way to get started.
 
 8. Click “Add File” and find a shapefile on your filesystem. Feel free
    to use the sample data provided in the QGIS manual
-   ([beginning-qgis-samples.zip](http://www.learnosm.org/files/beginning-qgis-samples.zip)).
+   ([beginning-qgis-samples.zip](https://www.learnosm.org/files/beginning-qgis-samples.zip)).
 
 9. Once you have selected a file, click “Import.” If everything goes
    smoothly, the output will read “Shapefile import completed.” 
@@ -253,7 +253,7 @@ database. The utility is easy to set-up, we simply need to download the
 program, and then we need to add its location to our system path.
 
 1. To download the windows version of osm2pgsql, navigate your web
-   browser to: [http://wiki.openstreetmap.org/wiki/Osm2pgsql#Windows](http://wiki.openstreetmap.org/wiki/Osm2pgsql#Windows) 
+   browser to: [https://wiki.openstreetmap.org/wiki/Osm2pgsql#Windows](https://wiki.openstreetmap.org/wiki/Osm2pgsql#Windows) 
    ![]({{site.baseurl}}/images/en/advanced/en_adv_ch1_image28.png)
 
 2. Download the file named osm2pgsql.zip
@@ -299,7 +299,7 @@ program, and then we need to add its location to our system path.
 13. Next to Name: type “dbsgeo.com”
 
 14. Next to plugins URL: type
-   “[http://qgis.dbsgeo.com](http://qgis.dbsgeo.com)” 
+   “[https://qgis.dbsgeo.com](https://qgis.dbsgeo.com)” 
    ![]({{site.baseurl}}/images/en/advanced/en_adv_ch1_image03.png)
 
 15. Click OK.
@@ -323,16 +323,16 @@ program, and then we need to add its location to our system path.
 
     Let’s use the plugin to import OpenStreetMap data into our database. If
     you don’t already have a .osm file that you can use, try downloading a
-    file from [http://metro.teczno.com/](http://metro.teczno.com/). This
+    file from [https://metro.teczno.com/](https://metro.teczno.com/). This
     site hosts many OSM extracts for different cities. Find a city to
     import and download the BZ2 file for it. BZ2 files are compressed
     versions of the normal .osm files. PBF files are even smaller, but our
     Windows version of osm2pgsql won’t work with this type of file. If this
     website doesn’t have a city you are interested in, you can get larger
     country-wide extracts from
-    [http://download.geofabrik.de/osm/](http://download.geofabrik.de/osm/.),
+    [https://download.geofabrik.de/osm/](https://download.geofabrik.de/osm/.),
     or download a specific area from
-    [http://hot-export.geofabrik.de](http://hot-export.geofabrik.de).
+    [https://hot-export.geofabrik.de](https://hot-export.geofabrik.de).
 
     ![]({{site.baseurl}}/images/en/advanced/en_adv_ch1_image09.png)
 
@@ -544,7 +544,7 @@ data file, which you can easily download from the GeoFabrik website. To
 download an OSM extract, find the link to the file and use wget to
 download the file on your Ubuntu system. For example:
 
-    wget http://download.geofabrik.de/openstreetmap/asia/indonesia.osm.pbf
+    wget https://download.geofabrik.de/openstreetmap/asia/indonesia.osm.pbf
 
 Depending on the size of the extract it may take some minutes to
 download.
@@ -603,7 +603,7 @@ https://github.com/springmeyer/win-osm-workshop/blob/master/Tutorial.md
 Jeff Haack:
 
 also this for OSM bright and imposm:
-http://mapbox.com/tilemill/docs/guides/osm-bright-ubuntu-quickstart/\#step\_1\_set\_up\_a\_database\_for\_your\_osm\_data
+https://mapbox.com/tilemill/docs/guides/osm-bright-ubuntu-quickstart/\#step\_1\_set\_up\_a\_database\_for\_your\_osm\_data
 
 [[c]](#cmnt_ref3)Paul Norman:
 


### PR DESCRIPTION
## Summary

Upgrades insecure HTTP links to HTTPS across 52 English documentation files, addressing #668.

- Updated links to OpenStreetMap-related sites (wiki.openstreetmap.org, tasks.hotosm.org, learnosm.org, etc.)
- Updated links to external tools and resources (fieldpapers.org, geofabrik.de, qgis.org, etc.)
- Updated links to documentation sites (wiki, docs, guides)

**Links intentionally kept as HTTP:**
- `localhost` URLs (local development servers)
- `SERVER_IP_ADDRESS` template placeholders
- IP address examples in configuration files

## Test plan

- [ ] Spot-check updated links to verify they resolve correctly with HTTPS
- [ ] Verify no localhost or template URLs were incorrectly modified

Addresses #668

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)